### PR TITLE
switch to single-threaded model

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ Socket.prototype._protectArray = function (ret, unwind) {
     return ret[1];
 };
 
-Socket.prototype._poll = function (revents) {
+Socket.prototype._poll = function(revents) {
     if(revents & nn.NN_POLLIN) {
         this._receive();
     }
@@ -69,26 +69,24 @@ Socket.prototype._receive = function () {
     this.emit('message', msg);
 };
 
-Socket.prototype._listen = function (cb) {
+Socket.prototype._listen = function(cb) {
     var self = this;
-    self._timer = setImmediate(function loop () {
+    self._timer = setImmediate(function loop() {
+
         if(self.closed) {
             return;
         }
 
         var mask = self.mask;
-        nn.NodeWorker(self.binding, mask, function (err, revents) {
+        var revents = nn.NonblockingPoll(self.binding, mask);
 
-            if(err) {
-                self.emit('error', new Error(nn.Strerr(err)));
-            }
+        if(revents < 0) {
+            self.emit('error', new Error(nn.Strerr(revents)));
+        } else if(revents > 0) {
+            cb(revents);
+        }
 
-            if(revents & mask) {
-                cb(revents);
-            }
-
-            self._timer = setImmediate(loop);
-        })
+        self._timer = setImmediate(loop);
     });
 };
 

--- a/test/term.js
+++ b/test/term.js
@@ -8,7 +8,7 @@ var nano = require('../');
 var test = require('tape');
 
 
-test('throw exception when seding on socket after term() called', function(t) {
+test('throw exception when sending on socket after term() called', function(t) {
     t.plan(1);
 
     var sock = nano.socket('pub');


### PR DESCRIPTION
Whilst learning the ins and outs of async, threads etc in node and V8, I discovered that we're spawning a new worker thread in order to call (**non-blocking**) _nn_poll()_. 

Since this call is asynchronous, it can be called from the event loop (i.e. does not need a separate worker thread). This makes the code significantly simpler, and provides a modest performance increase because of the saving in thread setup and synchronisation.

This PR can successfully execute the test suite in 3.3s (user) and 2.1s (sys) on average, versus 4.5s(user) and 3.3s (sys) on average for HEAD.

Is there some compelling reason that I'm not aware of why the poll needs to be in a separate thread?
