### PR TITLE
Adds Socket::transform and Socket::restore.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -130,7 +130,7 @@ Socket.prototype._send = function (buf, flags) {
         this.mask = nn.NN_POLLOUT | nn.NN_POLLIN;
     }
 
-    if (this.transform && typeof this.tranform === 'function') buf = this.transform(buf);
+    if (this.transform && typeof this.transform === 'function') buf = this.transform(buf);
     if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
     return this._protect(nn.Send(this.binding, buf, flags), function () {
         this.queue.unshift([buf, flags]);

--- a/test/transform.js
+++ b/test/transform.js
@@ -8,6 +8,7 @@ var nano = require('../');
 var test = require('tape');
 
 nano.Socket.prototype.transform = function (buf) {
+    if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
     return Buffer.concat([new Buffer([0x00]), buf]);
 }
 


### PR DESCRIPTION
Like I recommended in the `zmq` module, I want an easy hook to be able to add rich data types like [structured clone](https://github.com/tessel/structured-clone) into message passing.

This adds the optional socket methods Socket::transform and Socket::restore which, if implemented, call those functions to encode and decode a buffer according to the implementation.

If they are not implemented, it's a noop.
