### PR TITLE
Implement non-blocking polling of sockets. (Not ready yet)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -126,6 +126,9 @@ Socket.prototype._poll = function (revents) {
 };
 
 Socket.prototype._send = function (buf, flags) {
+    if (this.closed) {
+        return;
+    }
     if(this.type == 'surveyor') {
         this.mask = nn.NN_POLLOUT | nn.NN_POLLIN;
     }
@@ -133,12 +136,19 @@ Socket.prototype._send = function (buf, flags) {
     if (this.transform) buf = this.transform(buf);
     if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
     return this._protect(nn.Send(this.binding, buf, flags), function () {
-        this.queue.unshift(buf);
+        this.queue.unshift([buf, flags]);
     });
 };
 
 Socket.prototype._receive = function () {
+    if (this.closed) {
+        return;
+    }
+
     var msg = nn.Recv(this.binding, 0);
+    if (msg == -1) {
+        return;
+    }
 
     if(this.type == 'surveyor') {
         if(msg < 0 && nn.Errno() == nn.EFSM) {
@@ -153,24 +163,15 @@ Socket.prototype._receive = function () {
 
 Socket.prototype._listen = function (cb) {
     var self = this;
-    self._timer = setImmediate(function loop () {
-        if(self.closed) {
-            return;
-        }
+    if(self.closed) {
+        return;
+    }
 
-        var mask = self.mask;
-        nn.NodeWorker(self.binding, mask, function (err, revents) {
-
-            if(err) {
-                self.emit('error', new Error(nn.Strerr(err)));
-            }
-
-            if(revents & mask) {
-                cb(revents);
-            }
-
-            self._timer = setImmediate(loop);
-        })
+    this._pollReceive = nn.PollReceiveSocket(self.binding, function (events) {
+        if (self.mask & nn.NN_POLLIN) cb(nn.NN_POLLIN);
+    });
+    this._pollSend = nn.PollSendSocket(self.binding, function (events) {
+        if (self.mask & nn.NN_POLLOUT) cb(nn.NN_POLLOUT);
     });
 };
 
@@ -187,6 +188,7 @@ Socket.prototype.connect = function (addr) {
 }
 
 Socket.prototype.flush = function () {
+    this.sendable = !this.queue.length;
     while(this.queue.length) {
         var entry = this.queue.shift();
         this._send(entry[0], Number(entry[1]) || 0);
@@ -195,8 +197,14 @@ Socket.prototype.flush = function () {
 
 Socket.prototype.close = function () {
     if(!this.closed) {
+        // Prevent "Bad file descriptor" from triggering loop
         this.closed_status = nn.Close(this.binding);
         this.closed = true;
+
+        this._pollReceive && nn.PollStop(this._pollReceive);
+        this._pollSend && nn.PollStop(this._pollSend);
+        this._pollReceive = this._pollSend = null;
+
         return this.closed_status;
     }
 
@@ -211,6 +219,9 @@ Socket.prototype.close = function () {
 
 Socket.prototype.send = function (buf, flags) {
     this.queue.push([buf, flags]);
+    if (this.sendable) {
+        this.flush();
+    }
 
     return buf.length;
 };

--- a/src/node_pointer.h
+++ b/src/node_pointer.h
@@ -1,0 +1,75 @@
+#ifndef __NODE_POINTER_H__
+#define __NODE_POINTER_H__
+
+#include <node.h>
+#include "nan.h"
+
+/*
+ * Helper functions for treating node Buffer instances as C "pointers".
+ */
+ 
+#include "v8.h"
+#include "node_buffer.h"
+ 
+/*
+ * Called when the "pointer" is garbage collected.
+ */
+ 
+inline static void wrap_pointer_cb(char *data, void *hint) {
+  //fprintf(stderr, "wrap_pointer_cb\n");
+}
+ 
+/*
+ * Wraps "ptr" into a new SlowBuffer instance with size "length".
+ */
+ 
+inline static v8::Handle<v8::Value> WrapPointer(void *ptr, size_t length) {
+  void *user_data = NULL;
+  node::Buffer *buf = node::Buffer::New((char *)ptr, length, wrap_pointer_cb, user_data);
+  return buf->handle_;
+}
+ 
+/*
+ * Wraps "ptr" into a new SlowBuffer instance with length 0.
+ */
+ 
+inline static v8::Handle<v8::Value> WrapPointer(void *ptr) {
+  return WrapPointer((char *)ptr, 0);
+}
+ 
+/*
+ * Unwraps Buffer instance "buffer" to a C `char *` with the offset specified.
+ */
+ 
+inline static char * UnwrapPointer(v8::Handle<v8::Value> buffer, int64_t offset) {
+  if (node::Buffer::HasInstance(buffer)) {
+    return node::Buffer::Data(buffer.As<v8::Object>()) + offset;
+  } else {
+    return NULL;
+  }
+}
+ 
+/*
+ * Unwraps Buffer instance "buffer" to a C `char *` (no offset applied).
+ */
+ 
+ 
+inline static char * UnwrapPointer(v8::Handle<v8::Value> buffer) {
+  if (node::Buffer::HasInstance(buffer)) {
+    return node::Buffer::Data(buffer.As<v8::Object>());
+  } else {
+    return NULL;
+  }
+}
+ 
+/**
+ * Templated version of UnwrapPointer that does a reinterpret_cast() on the
+ * pointer before returning it.
+ */
+ 
+template <typename Type>
+inline static Type UnwrapPointer(v8::Handle<v8::Value> buffer) {
+  return reinterpret_cast<Type>(UnwrapPointer(buffer));
+}
+
+#endif

--- a/test/inproc.js
+++ b/test/inproc.js
@@ -111,6 +111,7 @@ test('inproc socket survey', function (t) {
     rep3.on('message', answer);
 
     var count = 0;
+    console.log('msg');
     sur.on('message', function (buf) {
         t.ok(buf.toString() == msg2, buf.toString() + ' == ' + msg2);
 

--- a/test/onlysurvey.js
+++ b/test/onlysurvey.js
@@ -1,0 +1,56 @@
+// http://tim.dysinger.net/posts/2013-09-16-getting-started-with-nanomsg.html
+
+var assert = require('assert');
+var should = require('should');
+var nano = require('../');
+var nn = nano._bindings;
+var fs = require('fs');
+
+var test = require('tape');
+
+test('inproc socket survey', function (t) {
+    t.plan(3);
+
+    var sur = nano.socket('surveyor');
+    sur.name = 'survey'
+    var rep1 = nano.socket('respondent');
+    rep1.name = 'rep1'
+    var rep2 = nano.socket('respondent');
+    rep2.name = 'rep2'
+    var rep3 = nano.socket('respondent');
+    rep3.name = 'rep3'
+
+    var addr = 'inproc://survey';
+    var msg1 = 'knock knock';
+    var msg2 = "who's there?";
+
+    sur.bind(addr);
+    rep1.connect(addr);
+    rep2.connect(addr);
+    rep3.connect(addr);
+
+    function answer (buf) {
+        this.send(msg2);
+    }
+
+    rep1.on('message', answer);
+    rep2.on('message', answer);
+    rep3.on('message', answer);
+
+    var count = 0;
+    console.log('msg');
+    sur.on('message', function (buf) {
+        t.ok(buf.toString() == msg2, buf.toString() + ' == ' + msg2);
+
+        if (++count == 3) {
+            sur.close();
+            rep1.close();
+            rep2.close();
+            rep3.close();
+        }
+    });
+
+    setTimeout(function () {
+        sur.send(msg1);
+    }, 100);
+});

--- a/test/standalone/term.js
+++ b/test/standalone/term.js
@@ -15,6 +15,7 @@ test('throw exception when seding on socket after term() called', function (t) {
     nano.term();
 
     sock.on('error', function (err) {
+    	console.log(err);
         t.ok('error was thrown on send after term');
         sock.close();
     });

--- a/test/transform.js
+++ b/test/transform.js
@@ -8,6 +8,7 @@ var nano = require('../');
 var test = require('tape');
 
 nano.Socket.prototype.transform = function (buf) {
+    if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
 	return Buffer.concat([new Buffer([0x00]), buf]);
 }
 


### PR DESCRIPTION
Got tired of nanomsg pegging my CPU and causing my fan to turn on. :) This uses the libuv API for socket polling directly, so nanomsg doesn't have to implement its own polling infrastructure.

Opening this PR, but there's a few bugs left to fix. Right now it passes all tests but it fails on my own project. I'll write the additional test and include it.

CPU usage doesn't actually go down, but I believe this is because the surveyor socket is enabled at the wrong time and returning -1 basically in a loop.

Additionally, I accidentally rebased this off another feature branch, so I should land those first.
