### PR TITLE
Trying to bind on a used port in Nanomsg will abort() the whole process.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 var nn = require('bindings')('node_nanomsg.node');
 
 var util = require('util');
+var url = require('url');
 var EventEmitter = require('events').EventEmitter;
 
 
@@ -177,12 +178,41 @@ Socket.prototype._stopPollReceive = function () {
  * Socket API
  */
 
-Socket.prototype.bind = function (addr) {
-    return this._protect(nn.Bind(this.binding, addr));
+// nanomsg ABORTS when port is used,
+// so check to see if port is available in node first.
+function isPortAvailable (addr, next) {
+    var server = require('net').createServer();
+    server.on('error', function (err) {
+        next(err);
+        next = null;
+    }.bind(this))
+    server.on('listening', function () {
+        server.close();
+    });
+    server.on('close', function () {
+        next && next();
+        next = null;
+    })
+
+    server.listen(url.parse(addr).port, url.parse(addr).hostname);
 }
 
+Socket.prototype._protectAddress = function (fn, event) {
+    if (err) return this.emit('error', err);
+    var ret = this._protect(fn(this.binding, addr));
+    if (ret !== null) this.emit(event, ret);
+}
+
+Socket.prototype.bind = function (addr) {
+    if (url.parse(addr).protocol == 'tcp:') {
+        isPortAvailable(addr, this_protectAddress.bind(this, nn.Bind, 'listening'));
+    } else {
+        setImmediate(this_protectAddress.bind(this, nn.Bind, 'listening'));
+    }
+};
+
 Socket.prototype.connect = function (addr) {
-    return this._protect(nn.Connect(this.binding, addr));
+    setImmediate(this._protectAddress.bind(this, nn.Connect, 'connected'));
 }
 
 Socket.prototype.flush = function () {

--- a/test/usedports.js
+++ b/test/usedports.js
@@ -1,0 +1,31 @@
+// http://tim.dysinger.net/posts/2013-09-16-getting-started-with-nanomsg.html
+
+var assert = require('assert');
+var should = require('should');
+var nano = require('../');
+
+var test = require('tape');
+
+test('inproc socket survey', function (t) {
+    t.plan(3);
+
+    var sur = nano.socket('surveyor');
+    sur.bind('tcp://127.0.0.1:22');
+    sur.on('error', function () {
+        t.ok(true, 'privileged port throws error');
+    })
+
+    var run = nano.socket('surveyor');
+    run.bind('tcp://127.0.0.1:6557');
+    run.on('listening', function () {
+        t.ok(true, 'can bind to 6557');
+
+        setTimeout(function () {
+        var run2 = nano.socket('surveyor');
+        run2.bind('tcp://127.0.0.1:6557');
+        run2.on('error', function () {
+            t.ok(true, 'cannot bind to 6557 twice');
+        });
+        }, 1000);
+    })
+});


### PR DESCRIPTION
This is a misfeature in nanomsg. The Node module and should provide the option to mitigate this issue:

https://github.com/nanomsg/nanomsg/issues/235

Since it requires changes to the nanomsg FSM I'll propose a workaround in Node for the short-term. An async function which checks for a port's availability, cleans up, and throws an `error` event or otherwise succeeds.

Obviously there is time enough for a race condition but this might mitigate the majority of common use.