### PR TITLE
Updated to NAN 1.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "bindings": "1.1.1",
-    "nan": "~1.3.0"
+    "nan": "~1.5.0"
   },
   "devDependencies": {
     "mocha": "~1.18.2",


### PR DESCRIPTION
Fix for https://github.com/nickdesaulniers/node-nanomsg/issues/40

Tests does pass on Ubuntu with io.js 1.0.3.