### PR TITLE
nanomsg streams: subclass Socket stream from Duplex base class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ perf:
 	node perf/local_thr.js tcp://127.0.0.1:5556 1 100000& node perf/remote_thr.js tcp://127.0.0.1:5556 1 100000 && wait
 
 bench:
-	node perf/local_lat.js tcp://127.0.0.1:5555 10 1000& node perf/remote_lat.js tcp://127.0.0.1:5555 10 1000 && wait
+	node perf/local_lat.js tcp://127.0.0.1:5555 10 10000& node perf/remote_lat.js tcp://127.0.0.1:5555 10 10000 && wait
 	node perf/local_thr.js tcp://127.0.0.1:5556 10 100000& node perf/remote_thr.js tcp://127.0.0.1:5556 10 100000 && wait
 
 full: clean ALL test

--- a/examples/multisub.js
+++ b/examples/multisub.js
@@ -11,20 +11,20 @@ sub1.connect(addr);
 sub2.connect(addr);
 sub3.connect(addr);
 
-sub1.on('message', function (buf) {
-    console.log("sub1 got: %s", buf.toString());
+sub1.on('data', function (str) {
+  console.log('sub1 got: %s', str);
+  sub1.close();
 });
-
-sub2.on('message', function (buf) {
-    console.log("sub2 got: %s", buf.toString());
+sub2.on('data', function (str) {
+  console.log('sub2 got: %s', str);
+  sub2.close();
 });
-
-sub3.on('message', function (buf) {
-    console.log("sub3 got: %s", buf.toString());
+sub3.on('data', function (str) {
+  console.log('sub2 got: %s', str);
+  sub3.close();
 });
 
 setTimeout(function () {
-    console.log("PUBLISHING...");
-    pub.send("Hello from nanomsg!");
+  console.log("PUBLISHING...");
+  pub.send("Hello from nanomsg!");
 }, 100);
-

--- a/examples/pipeline.js
+++ b/examples/pipeline.js
@@ -1,18 +1,16 @@
-var nano = require('../');
+var nano = require('..');
 
-var pull = nano.socket('pull');
+var pull = nano.socket('pull', {encoding:'utf8'} );
 var push = nano.socket('push');
 
-var addr = 'tcp://127.0.0.1:7789'
-pull.bind(addr);
-push.connect(addr);
+var addr = 'tcp://127.0.0.1:7789';
+pull.connect(addr);
+push.bind(addr);
 
-pull.on('message', function (buf) {
-	console.log(buf.toString());
-	pull.close();
-	push.close();
-});
+pull.on('data', console.log);
 
-setTimeout(function () {
-	push.send("Hello from nanomsg!");
-}, 100);
+setInterval( send, 100 );
+
+function send(){
+	push.send('hello from nanomsg stream api');
+}

--- a/examples/pubsub.js
+++ b/examples/pubsub.js
@@ -1,5 +1,4 @@
-var nano = require('../');
-
+var nano = require('..');
 var pub = nano.socket('pub');
 var sub = nano.socket('sub');
 
@@ -7,12 +6,9 @@ var addr = 'tcp://127.0.0.1:7789'
 pub.bind(addr);
 sub.connect(addr);
 
-sub.on('message', function (buf) {
-	console.log(buf.toString());
-	pub.close();
-	sub.close();
-});
+sub.pipe(process.stdout);
+setInterval( send, 100 );
 
-setTimeout(function () {
-	pub.send("Hello from nanomsg!");
-}, 100);
+function send(){
+  pub.send('hello from nanomsg stream api\n');
+}

--- a/examples/transforms.js
+++ b/examples/transforms.js
@@ -1,0 +1,40 @@
+var nano = require('..')
+
+var pub = nano.socket('pub');
+var sub = nano.socket('sub');
+
+pub.bind('inproc://transform');
+sub.connect('inproc://transform');
+
+/**
+ * minimal transform stream implementation
+ */
+require('util').inherits(thr, require('stream').Transform);
+function thr(fn){
+  this._transform = fn;
+  require('stream').Transform.call(this);
+}
+
+/**
+ * pipe from a readable source to minimal transform streams
+ */
+var t = new thr(function (msg, _, cb){
+  process.stdout.write('transformed: ' + msg + '\n'); //write to stdout stream
+  this.emit('destroy');
+  cb();
+});
+
+sub
+  .pipe(new thr(function (msg, _, cb){
+    console.log('original: ' + msg);  //original: hello from nanømsg
+    this.push(msg + ' and cheers!');
+    return cb();
+  }))
+  .pipe(t);
+
+pub.send('hello from nanømsg');
+
+t.on('destroy', cleanup); //do some cleanup
+function cleanup(){
+  return sub.close();
+}

--- a/examples/writablepipe.js
+++ b/examples/writablepipe.js
@@ -1,0 +1,16 @@
+var nano = require('..')
+var pub   = nano.socket('pub'),       push  = nano.socket('push');
+var sub   = nano.socket('sub'),       pull  = nano.socket('pull');
+pub.bind('tcp://127.0.0.1:3333');     push.bind('tcp://127.0.0.1:4444');
+sub.connect('tcp://127.0.0.1:3333');  pull.connect('tcp://127.0.0.1:4444');
+
+// setEncoding formats inbound message type
+sub.setEncoding('utf8');
+
+sub.on('data', function (msg) {
+  console.log(msg); //hello from a push socket!
+})
+
+pull.pipe(pub); //pipe readable sockets to any writable socket or stream
+
+setInterval( function(){ push.send('hello from a push socket!') }, 100 );

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
-var nn = require('bindings')('node_nanomsg.node');
-
-var util = require('util');
-var EventEmitter = require('events').EventEmitter;
+var nn            = require('bindings')('node_nanomsg.node');
+var util          = require('util');
+var EventEmitter  = require('events').EventEmitter;
+var Duplex        = require('stream').Duplex;
 
 /**
  * generic socket-level NN_SOL_SOCKET options
@@ -121,12 +121,21 @@ function Socket (type, opts) {
   }
 
   /* start listening for inbound messages */
-  if(this.af_domain === nn.AF_SP) {
-    if (this.receiver) this._startPollReceive();
+  if (this.af_domain === nn.AF_SP && this.receiver) {
+    this._startPollReceive();
   }
+
+  if (!opts.hasOwnProperty('objectMode')) {
+    // reduce the highwatermark from 16K msgs to 16msgs
+    // would be more useful if we have a backpressure mechanism
+    opts.objectMode = true;
+  }
+
+  Duplex.call(this, opts);
+
 }
 
-util.inherits(Socket, EventEmitter);
+util.inherits(Socket, Duplex);
 
 Socket.prototype._protect = function (ret, unwind) {
     if(ret < 0) {
@@ -166,11 +175,11 @@ Socket.prototype._send = function (msg, flags) {
 };
 
 Socket.prototype._receive = function () {
-    if (this.closed) return;
+  if (this.closed) return null;
 
-    var msg = nn.Recv(this.binding, 0);
+  var msg = nn.Recv(this.binding, 0);
 
-    if(this.type == 'surveyor') {
+  if(this.type == 'surveyor') {
         if(msg < 0 && nn.Errno() == nn.EFSM) {
             this._stopPollSend();
             this._stopPollReceive();
@@ -178,10 +187,10 @@ Socket.prototype._receive = function () {
             return;
         }
     }
-    if (msg == -1) return;
+  if (msg == -1) return null;
 
-    if (this.restore && typeof this.restore === 'function') msg = this.restore(msg);
-    this.emit('message', msg);
+  if (this.restore && typeof this.restore === 'function') msg = this.restore(msg);
+  return msg;
 };
 
 Socket.prototype._startPollSend = function () {
@@ -193,11 +202,11 @@ Socket.prototype._startPollSend = function () {
 }
 
 Socket.prototype._startPollReceive = function () {
-    if (!this._pollReceive) {
-        this._pollReceive = nn.PollReceiveSocket(this.binding, function (events) {
-            if (events) this._receive();
-        }.bind(this));
-    }
+  if (!this._pollReceive) {
+    this._pollReceive = nn.PollReceiveSocket(this.binding, function (events) {
+      if (events) this.push(this._receive());
+    }.bind(this));
+  }
 }
 
 Socket.prototype._stopPollSend = function () {
@@ -220,6 +229,13 @@ Socket.prototype._register = function(chan){
     this.emit('error', new Error( nn.Err() + ' : ' + chan));
   }
 };
+
+Socket.prototype._write = function(buf, _, cb){
+  this.send(buf);
+  cb();
+}
+
+Socket.prototype._read = function (n) {}
 
 /**
  * Socket API
@@ -307,7 +323,7 @@ Socket.prototype.survey = function (buf, callback) {
         this.removeListener('message', listener);
         callback(responses);
     })
-    this.on('message', listener)
+    this.on('data', listener)
     this.send(buf);
 }
 
@@ -338,6 +354,8 @@ function Device (sock1,sock2) {
     } else {
         throw new Error('expected at least one Socket argument');
     }
+
+    EventEmitter.call(this);
 }
 
 util.inherits(Device, EventEmitter);

--- a/perf/local_lat.js
+++ b/perf/local_lat.js
@@ -19,7 +19,7 @@ rc = s.bind(bind_to);
 assert(rc >= 0);
 
 var i = 0;
-s.on('message', function (data) {
+s.on('data', function (data) {
     assert.equal(data.length, sz);
     var nbytes = s.send(data);
     assert.equal(nbytes, sz);

--- a/perf/local_thr.js
+++ b/perf/local_thr.js
@@ -32,7 +32,7 @@ function finish() {
 }
 
 var i = 0;
-s.on('message', function (data) {
+s.on('data', function (data) {
     assert(data.length === sz);
     if (!sw) {
         sw = process.hrtime();

--- a/perf/remote_lat.js
+++ b/perf/remote_lat.js
@@ -41,7 +41,7 @@ function send() {
 }
 
 var i = 0;
-s.on('message', function (data) {
+s.on('data', function (data) {
     assert.equal(data.length, sz);
     if (++i === rts) {
         finish();

--- a/test/chan.js
+++ b/test/chan.js
@@ -20,7 +20,7 @@ test('adding and removing subscription channels', function (t) {
   var msgqty = -1; //starting here so first msg counted can be zero
   var sent = 0;
 
-  sub.on('message', function (buf) {
+  sub.on('data', function (buf) {
 
     var msg = String(buf);
 
@@ -81,7 +81,7 @@ test('without explicitly registering any channels, socket recvs 2+ msgs of diffe
   pub.bind(addr);
   sub.connect(addr);
 
-  sub.on('message', function (buf) {
+  sub.on('data', function (buf) {
 
     var msg = String(buf);
 
@@ -120,7 +120,7 @@ test('registration after socket creation: chan receives correctly prefixed messa
 
   sub.chan(['foo','hello']);
 
-  sub.on('message', function (buf) {
+  sub.on('data', function (buf) {
 
     var msg = String(buf);
 
@@ -159,7 +159,7 @@ test('channels registered by constructor get appropriately prefixed messages but
   pub.bind(addr);
   sub.connect(addr);
 
-  sub.on('message', function (buf) {
+  sub.on('data', function (buf) {
 
     var msg = String(buf);
 
@@ -198,7 +198,7 @@ test('multi-topic registration followed by calls to rmchan on all but one stops 
   pub.bind(addr);
   sub.connect(addr);
 
-  sub.on('message', function (buf) {
+  sub.on('data', function (buf) {
 
     var msg = String(buf);
 

--- a/test/inproc.js
+++ b/test/inproc.js
@@ -15,7 +15,7 @@ test('inproc socket pub sub', function (t) {
     pub.bind(addr);
     sub.connect(addr);
 
-    sub.on('message', function (buf) {
+    sub.on('data', function (buf) {
         t.equal(buf.toString(), msg);
 
         pub.close();
@@ -40,7 +40,7 @@ test('inproc socket pairs', function (t) {
     s1.bind(addr);
     s2.connect(addr);
 
-    s1.on('message', function (buf) {
+    s1.on('data', function (buf) {
         t.equal(buf.toString(), msg);
 
         s1.close();
@@ -66,12 +66,12 @@ test('inproc socket req rep', function (t) {
     rep.bind(addr);
     req.connect(addr);
 
-    rep.on('message', function (buf) {
+    rep.on('data', function (buf) {
         t.equal(buf.toString(), msg1, 'request received');
         rep.send(msg2);
     });
 
-    req.on('message', function (buf) {
+    req.on('data', function (buf) {
         t.equal(buf.toString(), msg2, 'reply received');
         req.close();
         rep.close();
@@ -103,12 +103,12 @@ test('inproc socket survey', function (t) {
         this.send(msg2);
     }
 
-    rep1.on('message', answer);
-    rep2.on('message', answer);
-    rep3.on('message', answer);
+    rep1.on('data', answer);
+    rep2.on('data', answer);
+    rep3.on('data', answer);
 
     var count = 0;
-    sur.on('message', function (buf) {
+    sur.on('data', function (buf) {
         t.ok(buf.toString() == msg2, buf.toString() + ' == ' + msg2);
 
         if (++count == 3) {
@@ -146,8 +146,8 @@ test('inproc socket bus', function (t) {
             bus.responseCount = 0;
 
             // Tally messages from other buses.
-            bus.on('message', function (msg) {
-                //console.error('#', 'received message from', msg.toString(), 'on', addr)
+            bus.on('data', function (msg) {
+                //console.error('#', 'received data from', msg.toString(), 'on', addr)
                 this.responseCount++;
                 current++;
 
@@ -237,9 +237,9 @@ test('inproc multiple socket pub sub', function (t) {
         }
     };
 
-    sub1.on('message', resp_handler);
-    sub2.on('message', resp_handler);
-    sub3.on('message', resp_handler);
+    sub1.on('data', resp_handler);
+    sub2.on('data', resp_handler);
+    sub3.on('data', resp_handler);
 
     setTimeout(function () {
         pub.send(msg);

--- a/test/ipc.js
+++ b/test/ipc.js
@@ -18,7 +18,7 @@ test('ipc socket pub sub', function (t) {
     pub.bind(addr);
     sub.connect(addr);
 
-    sub.on('message', function (buf) {
+    sub.on('data', function (buf) {
         t.equal(buf.toString(), msg);
 
         pub.close();
@@ -42,7 +42,7 @@ test('ipc socket pairs', function (t) {
     s1.bind(addr);
     s2.connect(addr);
 
-    s1.on('message', function (buf) {
+    s1.on('data', function (buf) {
         t.equal(buf.toString(), msg);
 
         s1.close();
@@ -67,12 +67,12 @@ test('ipc socket req rep', function (t) {
     rep.bind(addr);
     req.connect(addr);
 
-    rep.on('message', function (buf) {
+    rep.on('data', function (buf) {
         t.equal(buf.toString(), msg1, 'request received');
         rep.send(msg2);
     });
 
-    req.on('message', function (buf) {
+    req.on('data', function (buf) {
         t.equal(buf.toString(), msg2, 'reply received');
 
         req.close();
@@ -105,12 +105,12 @@ test('ipc socket survey', function (t) {
         this.send(msg2);
     }
 
-    rep1.on('message', answer);
-    rep2.on('message', answer);
-    rep3.on('message', answer);
+    rep1.on('data', answer);
+    rep2.on('data', answer);
+    rep3.on('data', answer);
 
     var count = 0;
-    sur.on('message', function (buf) {
+    sur.on('data', function (buf) {
         t.ok(buf.toString() == msg2, buf.toString() + ' == ' + msg2);
 
         if (++count == 3) {
@@ -149,8 +149,8 @@ test('ipc socket bus', function (t) {
             bus.responseCount = 0;
 
             // Tally messages from other buses.
-            bus.on('message', function (msg) {
-                //console.error('#', 'received message from', msg.toString(), 'on', addr);
+            bus.on('data', function (msg) {
+                //console.error('#', 'received data from', msg.toString(), 'on', addr);
                 this.responseCount++;
                 current++;
 
@@ -221,9 +221,9 @@ test('ipc multiple socket pub sub', function (t) {
         }
     };
 
-    sub1.on('message', resp_handler);
-    sub2.on('message', resp_handler);
-    sub3.on('message', resp_handler);
+    sub1.on('data', resp_handler);
+    sub2.on('data', resp_handler);
+    sub3.on('data', resp_handler);
 
     setTimeout(function () {
         pub.send(msg);

--- a/test/send.js
+++ b/test/send.js
@@ -1,7 +1,6 @@
 // https://github.com/chuckremes/nn-core/blob/master/spec/nn_send_spec.rb
 
-var nano = require('../');
-var nn = nano._bindings;
+var nano = require('..');
 var test = require('tape');
 
 // Polyfills Buffer.prototype.equals for Node.js 0.10
@@ -9,22 +8,22 @@ var test = require('tape');
 require('buffer-equals-polyfill');
 
 test('send returns number of bytes sent for bound socket', function (t) {
-    t.plan(1);
+  t.plan(1);
 
-    var sock = nano.socket('pub');
-    sock.bind('inproc://some_address');
-    var rc = sock.send('ABC');
-    t.equal(rc, 3);
-    sock.close();
+  var sock = nano.socket('pub');
+  sock.bind('inproc://some_address');
+  var rc = sock.send('ABC');
+  t.equal(rc, 3);
+  sock.close();
 });
 
 test('send returns number of bytes queued for unbound socket', function (t) {
-    t.plan(1);
+  t.plan(1);
 
-    var sock = nano.socket('pub');
-    var rc = sock.send('ABC');
-    t.equal(rc, 3);
-    sock.close();
+  var sock = nano.socket('pub');
+  var rc = sock.send('ABC');
+  t.equal(rc, 3);
+  sock.close();
 });
 
 test('send can take a string', function (t) {
@@ -38,7 +37,7 @@ test('send can take a string', function (t) {
   pub.bind(addr);
   sub.connect(addr);
 
-  sub.on('message', function (buf) {
+  sub.on('data', function (buf) {
     t.equal(buf.toString(), msg);
     t.equal(buf.length, msg.length);
     pub.close();
@@ -60,7 +59,7 @@ test('send can take a buffer', function (t) {
   pub.bind(addr);
   sub.connect(addr);
 
-  sub.on('message', function (buf) {
+  sub.on('data', function (buf) {
     t.equal(buf.toString(), msg.toString());
     t.equal(buf.length, msg.length);
     pub.close();
@@ -82,7 +81,7 @@ test('should not null terminate when sending strings', function (t) {
   pub.bind(addr);
   sub.connect(addr);
 
-  sub.on('message', function (buf) {
+  sub.on('data', function (buf) {
     if (buf[buf.length - 1] === 0) {
       t.fail();
     }
@@ -108,7 +107,7 @@ test('send can take a number', function (t) {
   pub.bind(addr);
   sub.connect(addr);
 
-  sub.on('message', function (buf) {
+  sub.on('data', function (buf) {
     t.equal(buf.toString(), msg.toString());
     pub.close();
     sub.close();
@@ -117,4 +116,3 @@ test('send can take a number', function (t) {
   var bytes = pub.send(msg);
   t.equal(bytes, msg.length);
 });
-

--- a/test/shutdown.js
+++ b/test/shutdown.js
@@ -28,7 +28,7 @@ test('shutdown the sub\'s connections',function(t){
 
   t.equal( Object.keys(sub.connected).length, 5, 'subscriber connections: 5' );
 
-  sub.on('message', function(msg){
+  sub.on('data', function(msg){
 
     //lets crash and burn if we keep getting messages after shutdown
     if (i > 10) throw 'it'

--- a/test/sockoptapi.js
+++ b/test/sockoptapi.js
@@ -79,7 +79,7 @@ test('ipv6 socket msg delivery', function (t) {
     pub.bind(addr);
     sub.connect(addr);
 
-    sub.on('message', function (buf) {
+    sub.on('data', function (buf) {
       t.equal(buf.toString(), msg);
 
       pub.close();

--- a/test/standalone/device.js
+++ b/test/standalone/device.js
@@ -13,8 +13,8 @@ test('create bidirectional device with two sockets', function (t) {
     var r1 = nano.socket('pair', { raw: 1 });
     var r2 = nano.socket('pair', { raw: 1 });
 
-    var addr1 = 'inproc://device1';
-    var addr2 = 'inproc://device2';
+    var addr1 = 'inproc://device01';
+    var addr2 = 'inproc://device02';
     var msg1 = "Hello";
     var msg2 = "World";
 
@@ -36,7 +36,7 @@ test('create bidirectional device with two sockets', function (t) {
     s1.connect(addr1);
     s2.connect(addr2);
 
-    s1.on('message', function (buf) {
+    s1.on('data', function (buf) {
         t.equal(buf.toString(), msg2);
         s1.close();
         s2.close();
@@ -45,7 +45,7 @@ test('create bidirectional device with two sockets', function (t) {
         nano.term();
     });
 
-    s2.on('message', function (buf) {
+    s2.on('data', function (buf) {
         t.equal(buf.toString(), msg1);
         s2.send(msg2);
     });

--- a/test/standalone/device2.js
+++ b/test/standalone/device2.js
@@ -10,8 +10,8 @@ var test = require('tape');
 test('create unidirectional device with two sockets', function (t) {
     t.plan(2);
 
-    var r1 = nano.socket('pull', { raw: 1 });
-    var r2 = nano.socket('push', { raw: 1 });
+    var r1 = nano.socket('pull', { raw: true });
+    var r2 = nano.socket('push', { raw: true });
 
     var addr1 = 'inproc://device1';
     var addr2 = 'inproc://device2';
@@ -35,7 +35,7 @@ test('create unidirectional device with two sockets', function (t) {
     s1.connect(addr1);
     s2.connect(addr2);
 
-    s2.on('message', function (buf) {
+    s2.on('data', function (buf) {
         t.equal(buf.toString(), msg);
         s1.close();
         s2.close();
@@ -49,4 +49,3 @@ test('create unidirectional device with two sockets', function (t) {
     }, 100);
 
 });
-

--- a/test/standalone/device3.js
+++ b/test/standalone/device3.js
@@ -10,7 +10,7 @@ var test = require('tape');
 test('create loopback device with one socket', function (t) {
     t.plan(2);
 
-    var r1 = nano.socket('bus', { raw: 1 });
+    var r1 = nano.socket('bus', { raw: true });
 
     var addr = 'inproc://device1';
     var msg = "Hello";
@@ -31,7 +31,7 @@ test('create loopback device with one socket', function (t) {
     s1.connect(addr);
     s2.connect(addr);
 
-    s2.on('message', function (buf) {
+    s2.on('data', function (buf) {
         t.equal(buf.toString(), msg);
         s1.close();
         s2.close();
@@ -45,4 +45,3 @@ test('create loopback device with one socket', function (t) {
     }, 100);
 
 });
-

--- a/test/streams.js
+++ b/test/streams.js
@@ -1,0 +1,36 @@
+var nano = require('..');
+var test = require('tape');
+
+test('pipe a thousand msgs between incompatible socket types', function(t){
+
+  var sent = 0, recv = 0;
+
+  var pub = nano.socket('pub', { tcpnodelay: true });
+  var sub = nano.socket('sub', { tcpnodelay: true });
+
+  var push = nano.socket('push');
+  var pull = nano.socket('pull');
+  pull.setEncoding('utf8'); //should also be able to do in `socket(type, opts)`
+
+  pub.bind('tcp://127.0.0.1:64999');
+  sub.connect('tcp://127.0.0.1:64999');
+
+  pull.bind('tcp://127.0.0.1:65000');
+  push.connect('tcp://127.0.0.1:65000');
+
+  sub.pipe(push);
+  pull.on('data', pullsocket);
+
+  while(sent++ < 1001) pub.send('hello from nanomsg pub socket!');
+
+  function pullsocket(msg){
+    if(recv++ > 999){
+      t.equal( msg, 'hello from nanomsg pub socket!', 'piped a pub/pull combo');
+      pub.close();
+      push.close();
+      pull.close();
+      sub.close();
+      t.end();
+    }
+  }
+});

--- a/test/survey.js
+++ b/test/survey.js
@@ -24,9 +24,9 @@ test('inproc socket survey', function (t) {
         this.send(msg2);
     }
 
-    rep1.on('message', answer);
-    rep2.on('message', answer);
-    rep3.on('message', answer);
+    rep1.on('data', answer);
+    rep2.on('data', answer);
+    rep3.on('data', answer);
 
     var count = 0;
     sur.survey(msg1, function (res) {

--- a/test/tcp.js
+++ b/test/tcp.js
@@ -18,7 +18,7 @@ test('tcp socket pub sub', function (t) {
     pub.bind(addr);
     sub.connect(addr);
 
-    sub.on('message', function (buf) {
+    sub.on('data', function (buf) {
         t.equal(buf.toString(), msg);
 
         pub.close();
@@ -42,7 +42,7 @@ test('tcp socket pairs', function (t) {
     s1.bind(addr);
     s2.connect(addr);
 
-    s1.on('message', function (buf) {
+    s1.on('data', function (buf) {
         t.equal(buf.toString(), msg);
 
         s1.close();
@@ -67,12 +67,12 @@ test('tcp socket req rep', function (t) {
     rep.bind(addr);
     req.connect(addr);
 
-    rep.on('message', function (buf) {
+    rep.on('data', function (buf) {
         t.equal(buf.toString(), msg1, 'request received');
         rep.send(msg2);
     });
 
-    req.on('message', function (buf) {
+    req.on('data', function (buf) {
         t.equal(buf.toString(), msg2, 'reply received');
 
         req.close();
@@ -104,12 +104,12 @@ test('tcp socket survey', function (t) {
     function answer (buf) {
         this.send(msg2);
     }
-    rep1.on('message', answer);
-    rep2.on('message', answer);
-    rep3.on('message', answer);
+    rep1.on('data', answer);
+    rep2.on('data', answer);
+    rep3.on('data', answer);
 
     var count = 0;
-    sur.on('message', function (buf) {
+    sur.on('data', function (buf) {
         t.ok(buf.toString() == msg2, buf.toString() + ' == ' + msg2);
 
         if (++count == 3) {
@@ -147,8 +147,8 @@ test('tcp socket bus', function (t) {
             bus.responseCount = 0;
 
             // Tally messages from other buses.
-            bus.on('message', function (msg) {
-                //console.error('#', 'received message from', msg.toString(), 'on', addr)
+            bus.on('data', function (msg) {
+                //console.error('#', 'received data from', msg.toString(), 'on', addr)
                 this.responseCount++;
                 current++;
 
@@ -219,9 +219,9 @@ test('tcp multiple socket pub sub', function (t) {
         }
     };
 
-    sub1.on('message', resp_handler);
-    sub2.on('message', resp_handler);
-    sub3.on('message', resp_handler);
+    sub1.on('data', resp_handler);
+    sub2.on('data', resp_handler);
+    sub3.on('data', resp_handler);
 
     setTimeout(function () {
         pub.send(msg);

--- a/test/transform.js
+++ b/test/transform.js
@@ -25,7 +25,7 @@ test('inproc socket pub sub', function (t) {
     pub.bind(addr);
     sub.connect(addr);
 
-    sub.on('message', function (buf) {
+    sub.on('data', function (buf) {
         t.equal(buf.slice(2).toString(), msg);
         t.equal(buf[0], 0xFF);
         t.equal(buf[1], 0x00);


### PR DESCRIPTION
PR builds directly on @tcr efforts, leveraging initial work and direction taken in https://github.com/nickdesaulniers/node-nanomsg/pull/30: 
* the Readable Stream's `_read(n){}` implementation is no different here.
* furthers #29, implementing a `Writeable`

#### other notable characteristics:
* revised program interface for all send and receive operations
* removes EventEmitter
* new API:
  - full blown Duplex interface: Writeable and Readable streams
  - from `.on('message', callback)` to `.on('data', callback)`
  - pipe all endpoints together from chainable  `pipe()` methods
  - socket’s `pipe()` method is essentially a flexible `zmq_proxy()` or `nn_device()`
  - io.js streams are domain, protocol, and transport agnostic
  - combine sockets in new ways and connect modules like [websocket stream](https://github.com/maxogden/websocket-stream)