### PR TITLE
Perf tests translated from nanomsg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,12 @@ clean:
 	rm -fr build && rm -rf node_modules
 
 perf:
-	node perf/local_lat.js tcp://127.0.0.1:5555 1 100000& node perf/remote_lat.js tcp://127.0.0.1:5555 1 100000
-	node perf/local_thr.js tcp://127.0.0.1:5556 1 100000& node perf/remote_thr.js tcp://127.0.0.1:5556 1 100000
+	node perf/local_lat.js tcp://127.0.0.1:5555 1 100000& node perf/remote_lat.js tcp://127.0.0.1:5555 1 100000 && wait
+	node perf/local_thr.js tcp://127.0.0.1:5556 1 100000& node perf/remote_thr.js tcp://127.0.0.1:5556 1 100000 && wait
 
 bench:
-	node perf/local_lat.js tcp://127.0.0.1:5555 10 1000& node perf/remote_lat.js tcp://127.0.0.1:5555 10 1000
-	node perf/local_thr.js tcp://127.0.0.1:5556 10 100000& node perf/remote_thr.js tcp://127.0.0.1:5556 10 100000
+	node perf/local_lat.js tcp://127.0.0.1:5555 10 1000& node perf/remote_lat.js tcp://127.0.0.1:5555 10 1000 && wait
+	node perf/local_thr.js tcp://127.0.0.1:5556 10 100000& node perf/remote_thr.js tcp://127.0.0.1:5556 10 100000 && wait
 
 full:
 	rm -fr build && rm -rf node_modules

--- a/perf/local_thr.js
+++ b/perf/local_thr.js
@@ -1,41 +1,43 @@
+'use strict';
+
 var nano = require('../');
 var assert = require('assert');
 
 if (process.argv.length != 5) {
-  console.log('usage: local_thr <bind-to> <message-size> <message-count>');
-  process.exit(1);
+    console.log('usage: local_thr <bind-to> <msg-size> <msg-count>');
+    process.exit(1);
 }
-
 var bind_to = process.argv[2];
-var message_size = Number(process.argv[3]);
-var message_count = Number(process.argv[4]);
-var counter = 0;
+var sz = Number(process.argv[3]);
+var count = Number(process.argv[4]);
 
-var sock = nano.socket('pull');
-sock.bind(bind_to);
+var s = nano.socket('pair');
+assert(s.binding !== -1);
+var rc = s.bind(bind_to);
+assert(rc >= 0);
 
-var timer;
+var sw;
 
-sock.on('message', function (data) {
-  if (!timer) {
-    console.log('started receiving');
-    timer = process.hrtime();
-  }
-
-  assert.equal(data.length, message_size, 'message-size did not match');
-  if (++counter === message_count) finish();
-})
-
-function finish(){
-  var endtime = process.hrtime(timer);
-  var sec = endtime[0] + (endtime[1]/1000000000);
-  var throughput = message_count / sec;
-  var megabits = (throughput * message_size * 8) / 1000000;
-
-  console.log('message size: %d [B]', message_size);
-  console.log('message count: %d', message_count);
-  console.log('mean throughput: %d [msg/s]', throughput.toFixed(0));
-  console.log('mean throughput: %d [Mbit/s]', megabits.toFixed(0));
-  console.log('overall time: %d secs and %d nanoseconds', endtime[0], endtime[1]);
-  sock.close();
+function finish() {
+    sw = process.hrtime(sw);
+    var total = sw[0] + (sw[1] / 1e9);
+    var thr = count / total;
+    var mbs = (thr * sz * 8) / 1000000;
+    console.log('message size: %d [B]', sz);
+    console.log('message count: %d', count);
+    console.log('throughput: %d [msg/s]', thr.toFixed(0));
+    console.log('throughput: %d [Mb/s]', mbs.toFixed(3));
+    rc = s.close();
+    assert(rc === 0);
 }
+
+var i = 0;
+s.on('message', function (data) {
+    assert(data.length === sz);
+    if (!sw) {
+        sw = process.hrtime();
+    }
+    if (++i === count) {
+        finish();
+    }
+});

--- a/perf/local_thr.js
+++ b/perf/local_thr.js
@@ -4,7 +4,7 @@ var nano = require('../');
 var assert = require('assert');
 
 if (process.argv.length != 5) {
-    console.log('usage: local_thr <bind-to> <msg-size> <msg-count>');
+    console.log('usage: node local_thr.js <bind-to> <msg-size> <msg-count>');
     process.exit(1);
 }
 var bind_to = process.argv[2];

--- a/perf/remote_thr.js
+++ b/perf/remote_thr.js
@@ -4,7 +4,7 @@ var nano = require('../');
 var assert = require('assert');
 
 if (process.argv.length != 5) {
-    console.log('usage: remote_thr <bind-to> <msg-size> <msg-count>');
+    console.log('usage: node remote_thr.js <bind-to> <msg-size> <msg-count>');
     process.exit(1);
 }
 


### PR DESCRIPTION
See https://github.com/nanomsg/nanomsg/tree/master/perf as a reference.

Recently added perf scripts, seem to be translated directly from node zmq bindings.
I believe we should target nanomsg for performances comparison:

- same output
- same socket types
- same time units make more sense to me.

A part from obvious translation, the use of setTimeout is replaced with ```flush```.