### PR TITLE
optval pointer fix

### DIFF
--- a/src/node_nanomsg.cc
+++ b/src/node_nanomsg.cc
@@ -148,17 +148,13 @@ NAN_METHOD(Setopt) {
 NAN_METHOD(Getopt) {
   NanScope();
 
-  int optval[1];
-  int option = args[2].integer;
-  size_t optsize = sizeof(optval);
+  size_t optsize;
+  int optval, option = args[2].integer;
+  optsize = sizeof (optval);
 
-  //check if the function succeeds
-  if(nn_getsockopt(S, args[1].integer, option, optval, &optsize) == 0){
-
-    if(option == NN_SOCKET_NAME) ret(NanNew<String>((char *)optval));
-
-    ret(NanNew<Number>(optval[0]));
-
+  //verify result
+  if(nn_getsockopt(S, args[1].integer, option, (char*) &optval, &optsize) == 0){
+    ret(NanNew<Number>(optval));
   } else {
     //pass the error back as an undefined return
     NanReturnUndefined();


### PR DESCRIPTION
@nickdesaulniers, following up a discussion we had about getsockopt args in #46:

> The third arg, optval, should be a void*. Passing a int [64] is probably not what you meant to do?

I'm pretty sure `NAN` or maybe node V8 is partial to `char*` over `void*`... though i guess it depends on the situtation/function we're talking about

> This does work, it's just using 63 * sizeof(int) bytes more of the stack than it needs to. It works because in C arrays decay into pointers when passed to functions. So you're allocating space for 64 ints on the stack, then passing the address of the first element, which gets filled. Since it's an array of ints, only the first element is ever populated.

> If you think about the C ABI, it's not possible to represent 64 ints in a single register on today's processors. That's why passing an array decays into a pointer. A kind of syntactic sugar. nn_getsockopt takes a void*, which works since optval decays into an int*.

> A few lines down, there is no need to access optval[0] since we don't need optval to be an array of ints, just an int.

agreed.
