### PR TITLE
perf node's net and udp modules for comparison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-.PHONY: clean check test perf bench full
+.PHONY: clean check test perf bench net udp full
 
 ALL:
+	git submodule update --init
 	npm i
 
 check:
-	npm t
+	npm i && npm t
 
 test:
 	npm t
@@ -20,6 +21,14 @@ bench:
 	node perf/local_lat.js tcp://127.0.0.1:5555 10 1000& node perf/remote_lat.js tcp://127.0.0.1:5555 10 1000 && wait
 	node perf/local_thr.js tcp://127.0.0.1:5556 10 100000& node perf/remote_thr.js tcp://127.0.0.1:5556 10 100000 && wait
 
+net:
+	node perf/net/local_lat.js tcp://127.0.0.1:45557 1 100000& node perf/net/remote_lat.js tcp://127.0.0.1:45557 1 100000 && wait
+	node perf/net/local_thr.js tcp://127.0.0.1:45558 1 100000& node perf/net/remote_thr.js tcp://127.0.0.1:45558 1 100000 && wait
+
+udp:
+	node perf/udp/local_thr.js udp://localhost:5559 6000 10000& node perf/udp/remote_thr.js udp://localhost:5559 6000 10000 && wait
+
 full:
+	git submodule update --init
 	rm -fr build && rm -rf node_modules
 	npm i && npm t

--- a/perf/net/local_lat.js
+++ b/perf/net/local_lat.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var net     = require('net')
+var assert  = require('assert');
+
+if (process.argv.length != 5) {
+  console.log('usage: node local_lat.js <bind-to> <msg-size> <roundtrips>');
+  process.exit(1);
+}
+var bind_to = process.argv[2].split('//')[1].split(':');
+var sz      = Number(process.argv[3]);
+var rts     = Number(process.argv[4]);
+
+var i       = 0;
+var s       = net.createServer({ setNoDelay: true }, function(sock) {
+  sock.pipe(sock);
+  sock.on('data', dataHandler);
+  sock.on('error', e );
+});
+s.listen(bind_to[1]);
+s.on('error', e );
+
+function dataHandler (data) {
+  assert.equal(data.length, sz);
+  if (++i === rts) s.unref();
+}
+
+function e (er){ require('util').log(er) }

--- a/perf/net/local_thr.js
+++ b/perf/net/local_thr.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var net       = require('net');
+var assert    = require('assert');
+
+if (process.argv.length != 5) {
+  console.log('usage: node local_thr.js <bind-to> <msg-size> <msg-count>');
+  process.exit(1);
+}
+var bind_to   = process.argv[2].split('//')[1].split(':');
+var sz        = Number(process.argv[3]);
+var count     = Number(process.argv[4]);
+
+var sw, i     = 0;
+var s         = net.createServer(function(sock) {
+  sock.pipe(sock)
+  sock.on('data', dataHandler);
+  sock.on('error', e );
+});
+
+s.listen(bind_to[1]);
+s.on('error', e );
+
+function dataHandler (data) {
+  assert(data.length === sz);
+  if (!sw) sw = process.hrtime();
+  if (++i === count)
+    return finish();
+}
+
+function finish() {
+  sw = process.hrtime(sw);
+  var total = sw[0] + (sw[1] / 1e9);
+  var thr = count / total;
+  var mbs = (thr * sz * 8) / 1000000;
+  console.log('message size: %d [B]', sz);
+  console.log('message count: %d', count);
+  console.log('throughput: %d [msg/s]', thr.toFixed(0));
+  console.log('throughput: %d [Mb/s]', mbs.toFixed(3));
+  s.unref();
+}
+
+setTimeout(function(){
+  process.exit(0);
+},9000)
+
+function e (er){ require('util').log(er) }

--- a/perf/net/remote_lat.js
+++ b/perf/net/remote_lat.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var net         = require('net');
+var assert      = require('assert');
+var sw, i       = 0;
+
+if (process.argv.length != 5) {
+    console.log('usage: node remote_lat.js <connect-to> <msg-size> <roundtrips>');
+    process.exit(1);
+}
+var connect_to  = process.argv[2].split('//')[1].split(':');
+var sz          = Number(process.argv[3]);
+var rts         = Number(process.argv[4]);
+var buf         = new Buffer(sz); buf.fill('o');
+var s           = new net.Socket({setNoDelay: true});
+
+
+setTimeout(function(){
+  sw = process.hrtime();
+  s.connect(connect_to[1], function() {
+    s.write(buf);
+  });
+},500);
+
+s.on('data', send );
+s.on('error', e );
+
+function send (data) {
+  assert.equal(data.length, sz);
+  s.write(buf);
+  if (++i == rts)
+    return finish();
+}
+function finish() {
+  sw = process.hrtime(sw);
+  var total = sw[0] * 1e6 + sw[1] / 1e3;
+  var lat = total / (rts * 2);
+  console.log('message size: %d [B]', sz);
+  console.log('roundtrip count: %d', rts);
+  console.log('average latency: %d [us]', lat.toFixed(3));
+
+  s.unref();
+}
+
+function e (er){ require('util').log(er) }

--- a/perf/net/remote_thr.js
+++ b/perf/net/remote_thr.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var net         = require('net');
+var assert      = require('assert');
+
+if (process.argv.length != 5) {
+  require('util').log('usage: node remote_thr.js <bind-to> <msg-size> <msg-count>');
+  process.exit(1);
+}
+var connect_to  = process.argv[2].split('//')[1].split(':');
+var sz          = Number(process.argv[3]);
+var count       = Number(process.argv[4])*1.1;
+var buf         = new Buffer(sz), i = 0;
+buf.fill('o');
+assert(buf.length === sz);
+
+var s = new net.Socket();
+setTimeout(function(){
+  s.connect(connect_to[1], function() {
+    s.write(buf);
+  });
+}, 1000)
+
+s.on('data', dataHandler );
+s.on('error', e );
+
+function dataHandler (data) {
+  assert(data.length === sz);
+  if(++i < count)
+    return s.write(buf);
+  return s.unref();
+};
+
+function e (er){ require('util').log(er) }
+
+//net module API socket.bufferSize
+//http://nodejs.org/api/net.html#net_socket_buffersize
+
+//net.Socket has the property that socket.write() always works.
+//This is to help users get up and running quickly.
+
+//The computer cannot always keep up with the amount of data that is written
+//to a socket - the network connection simply might be too slow. Node will
+//internally queue up the data written to a socket and send it out over the wire
+//when it is possible. (Internally it is polling on the socket's file descriptor
+//for being writable).
+
+//The consequence of this internal buffering is that memory may grow.
+//This property shows the number of characters currently buffered to be written.
+//(Number of characters is approximately equal to the number of bytes to be
+//  written, but the buffer may contain strings, and the strings are lazily
+//  encoded, so the exact number of bytes is not known.)
+
+//Users who experience large or growing bufferSize should attempt to "throttle"
+//the data flows in their program with pause() and resume().

--- a/perf/udp/local_thr.js
+++ b/perf/udp/local_thr.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var assert = require('assert');
+
+if (process.argv.length != 5) {
+    console.log('usage: node local_thr.js <bind-to> <msg-size> <msg-count>');
+    process.exit(1);
+}
+
+var bind_to = process.argv[2].split('//')[1].split(':');
+var sz = Number(process.argv[3]);
+var count = Number(process.argv[4]);
+
+var s = require('dgram').createSocket('udp4');
+var sw, i = 0;
+s.bind(bind_to[1]);
+s.on('message', handler);
+
+function handler(data) {
+    assert(data.length === sz);
+    if (!sw) sw = process.hrtime();
+    if (++i === count) finish();
+}
+
+function finish() {
+    sw = process.hrtime(sw);
+    var total = sw[0] + (sw[1] / 1e9);
+    var thr = count / total;
+    var mbs = (thr * sz * 8) / 1000000;
+    console.log('message size: %d [B]', sz);
+    console.log('message count: %d', count);
+    console.log('throughput: %d [msg/s]', thr.toFixed(0));
+    console.log('throughput: %d [Mb/s]', mbs.toFixed(3));
+    s.close(); process.exit(0);
+}

--- a/perf/udp/remote_thr.js
+++ b/perf/udp/remote_thr.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var dgram = require('dgram');
+var assert = require('assert');
+
+if (process.argv.length != 5) {
+    require('util').log('usage: node remote_thr.js <bind-to> <msg-size> <msg-count>');
+    process.exit(1);
+}
+
+var connect_to = process.argv[2].split('//')[1].split(':');
+var sz = Number(process.argv[3]);
+var count = Number(process.argv[4])*1.5;
+
+var s = dgram.createSocket('udp4')
+var buf = new Buffer(sz), i = 0;
+buf.fill('o');
+
+assert(buf.length === sz);
+
+do s.send(buf, 0, sz, connect_to[1], connect_to[0]);
+while(i++ < count);
+s.unref();


### PR DESCRIPTION
sometimes the situation calls for a different protocol, for example: UDP sockets establish the real limits of throughput

benchmark the options.

`thr` and `lat` tell us a lot depending on where and how they are run across the network (espeically different message sizes).

to compare node's TCP socket api, the `net` module run:

```bash
$ make net
```

for the standard datagram sockets shipped with io.js and node run:
```bash
$ make udp
```