### PR TITLE
fix deprecation warnings Fixes #49

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,16 +8,13 @@
     "nan": "~1.6.2"
   },
   "devDependencies": {
-    "mocha": "~1.18.2",
-    "chai": "~1.9.1",
-    "tape": "~2.12.0",
-    "tap": "~0.4.8",
-    "should": "~3.2.0-beta1",
     "esformatter": "0.0.16",
-    "tapr": "~0.1.3"
+    "should": "~3.2.0-beta1",
+    "tap-nyan": "0.0.2",
+    "tape": "~2.12.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/tapr test/*.js test/standalone/*.js",
+    "test": "find test/*.js test/standalone/*.js | xargs -n 1 node | node_modules/tap-nyan/bin/cmd.js",
     "beaut": "find . -path ./node_modules -prune -or -name '*.js' -exec sh -c 'cp -a {} {}.tmp; esformatter {} >{}.tmp && mv {}.tmp {}' \\;"
   },
   "keywords": [

--- a/test/inproc.js
+++ b/test/inproc.js
@@ -150,7 +150,7 @@ test('inproc socket bus', function (t) {
 
             // Tally messages from other buses.
             bus.on('message', function (msg) {
-                console.error('#', 'received message from', msg.toString(), 'on', addr)
+                //console.error('#', 'received message from', msg.toString(), 'on', addr)
                 this.responseCount++;
                 current++;
 
@@ -175,7 +175,7 @@ test('inproc socket bus', function (t) {
 
         for (var i = 0; i < keys.length; i++) {
             for (var j = i+1; j < keys.length; j++) {
-                console.error('#', 'connecting', keys[i], 'to', keys[j]);
+                //console.error('#', 'connecting', keys[i], 'to', keys[j]);
                 buses[keys[i]].connect(keys[j]);
             }
         }
@@ -184,7 +184,7 @@ test('inproc socket bus', function (t) {
     // Send messages on every bus.
     setTimeout(function () {
         Object.keys(buses).forEach(function (addr) {
-            console.error('#', 'writing on', addr, addr);
+            //console.error('#', 'writing on', addr, addr);
             buses[addr].send(addr);
         });
     }, 1000);

--- a/test/ipc.js
+++ b/test/ipc.js
@@ -153,7 +153,7 @@ test('ipc socket bus', function (t) {
 
             // Tally messages from other buses.
             bus.on('message', function (msg) {
-                console.error('#', 'received message from', msg.toString(), 'on', addr);
+                //console.error('#', 'received message from', msg.toString(), 'on', addr);
                 this.responseCount++;
                 current++;
 
@@ -178,7 +178,7 @@ test('ipc socket bus', function (t) {
 
         for (var i = 0; i < keys.length; i++) {
             for (var j = i+1; j < keys.length; j++) {
-                console.error('#', 'connecting', keys[i], 'to', keys[j]);
+                //console.error('#', 'connecting', keys[i], 'to', keys[j]);
                 buses[keys[i]].connect(keys[j]);
             }
         }
@@ -187,7 +187,7 @@ test('ipc socket bus', function (t) {
     // Send messages on every bus.
     setTimeout(function () {
         Object.keys(buses).forEach(function (addr) {
-            console.error('#', 'writing on', addr, addr);
+            //console.error('#', 'writing on', addr, addr);
             buses[addr].send(addr);
         });
     }, 1000);

--- a/test/tcp.js
+++ b/test/tcp.js
@@ -151,7 +151,7 @@ test('tcp socket bus', function (t) {
 
             // Tally messages from other buses.
             bus.on('message', function (msg) {
-                console.error('#', 'received message from', msg.toString(), 'on', addr)
+                //console.error('#', 'received message from', msg.toString(), 'on', addr)
                 this.responseCount++;
                 current++;
 
@@ -176,7 +176,7 @@ test('tcp socket bus', function (t) {
 
         for (var i = 0; i < keys.length; i++) {
             for (var j = i+1; j < keys.length; j++) {
-                console.error('#', 'connecting', keys[i], 'to', keys[j]);
+                //console.error('#', 'connecting', keys[i], 'to', keys[j]);
                 buses[keys[i]].connect(keys[j]);
             }
         }
@@ -185,7 +185,7 @@ test('tcp socket bus', function (t) {
     // Send messages on every bus.
     setTimeout(function () {
         Object.keys(buses).forEach(function (addr) {
-            console.error('#', 'writing on', addr, addr);
+            //console.error('#', 'writing on', addr, addr);
             buses[addr].send(addr);
         });
     }, 1000);


### PR DESCRIPTION
review? @reqshark 

The previous test harness was creating deprecation warnings, see #49 .  It also was incorrectly counting the number of tests.

With this PR, the correct total number of tests is 823, not 844.  21+3+19+12+14+13+2+22+3+26+4+188+470+0+13+2+3+3+2+2+1 === 823 !==
 844.