### PR TITLE
sockopt api: add ipv6 support via method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ var sol = {
   sndprio         : nn.NN_SNDPRIO,
   rcvprio         : nn.NN_RCVPRIO,
   tcpnodelay      : nn.NN_TCP_NODELAY,
+  ipv6            : nn.NN_IPV4ONLY,
 }
 
 /**
@@ -315,24 +316,45 @@ Socket.prototype.maxreconn  = opt('maxreconn');
 Socket.prototype.sndprio    = opt('sndprio');
 Socket.prototype.rcvprio    = opt('rcvprio');
 
-/* tcpnodelay sockopt method. this one is a little different */
+/* ipv6 & tcpnodelay sockopt methods. these two opts are a little different */
+Socket.prototype.ipv6 = function (bool) {
+  if(arguments.length){
+    if(bool){
+      if(nn.Setopt(this.binding, nn.NN_SOL_SOCKET, sol.ipv6, 0) > -1)
+        return true;
+      throw new Error(nn.Err() + ': '+this.type + ' ipv6@activing\n');
+    } else {
+      if(nn.Setopt(this.binding, nn.NN_SOL_SOCKET, sol.ipv6, 1) > -1)
+        return false;
+      throw new Error(nn.Err() + ': '+this.type+' ipv6@deactiving\n');
+    }
+  } else {
+    switch(nn.Getopt(this.binding, nn.NN_SOL_SOCKET, sol.ipv6)){
+      case 1: return false;
+      case 0: return true;
+      default:
+        throw new Error(nn.Err() +': '+this.type+' ipv6@getsockopt\n');
+    }
+  }
+}
+
 Socket.prototype.tcpnodelay = function (bool) {
   if(arguments.length){
     if(bool){
       if(nn.Setopt(this.binding, nn.NN_TCP, nn.NN_TCP_NODELAY, 1) > -1)
         return true;
-      throw new Error(nn.Err() + ': '+this.type + ' nodelay@'+'activing'+'\n');
+      throw new Error(nn.Err() + ': '+this.type + ' nodelay@activing\n');
     } else {
       if(nn.Setopt(this.binding, nn.NN_TCP, nn.NN_TCP_NODELAY, 0) > -1)
         return false;
-      throw new Error(nn.Err() + ': '+this.type+' nodelay@'+'deactiving'+'\n');
+      throw new Error(nn.Err() + ': '+this.type+' nodelay@deactiving\n');
     }
   } else {
     switch(nn.Getopt(this.binding, nn.NN_TCP, nn.NN_TCP_NODELAY)){
       case 1: return true;
       case 0: return false;
       default:
-        throw new Error(nn.Err() +': '+this.type+' nodelay@'+'getsockopt'+'\n');
+        throw new Error(nn.Err() +': '+this.type+' nodelay@getsockopt\n');
     }
   }
 }

--- a/test/sockoptapi.js
+++ b/test/sockoptapi.js
@@ -58,6 +58,35 @@ test('sockopt api methods', function(t){
   t.equal( sock.rcvprio(10), true, 'sock.rcvprio(10) sets: 10 priority');
   t.equal( sock.rcvprio(), 10, 'sock.rcvprio() gets: 10');
 
+  //ipv6
+  t.equal( sock.ipv6(), false, 'sock.ipv6() gets: false');
+  t.equal( sock.ipv6(true), true, 'sock.ipv6(true) gets: true');
+  t.equal( sock.ipv6(), true, 'sock.ipv6() gets: true');
+
   sock.close();
   t.end();
-})
+});
+
+test('ipv6 socket msg delivery', function (t) {
+    t.plan(1);
+
+    var pub = nano.socket('pub', { ipv6: true });
+    var sub = nano.socket('sub', { ipv6: true });
+
+    var addr = 'tcp://::1:6000';
+    var msg = 'hello world';
+
+    pub.bind(addr);
+    sub.connect(addr);
+
+    sub.on('message', function (buf) {
+      t.equal(buf.toString(), msg);
+
+      pub.close();
+      sub.close();
+    });
+
+    setTimeout(function () {
+      pub.send(msg);
+    }, 100);
+});


### PR DESCRIPTION
fixes #63

not activating ipv6 as a default.