### PR TITLE
a zerocopy send method

### DIFF
--- a/examples/zerocopy.js
+++ b/examples/zerocopy.js
@@ -1,0 +1,13 @@
+var nano = require('..');
+var pub = nano.socket('pub');
+var sub = nano.socket('sub');
+var buf = Buffer('hello from nanomsg!');
+
+pub.bind('tcp://127.0.0.1:55555');
+sub.connect('tcp://127.0.0.1:55555');
+sub.on('message', function(msg){ console.log(String(msg)) });
+
+setInterval(send, 100);
+function send(){
+  return pub.zerocopySend(buf);
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -283,6 +283,10 @@ Socket.prototype.send = function (buf, flags) {
     return buf.length;
 };
 
+Socket.prototype.zerocopySend = function (buf) {
+  return nn.ZerocopySend(this.binding, buf);
+}
+
 /* returns an int, a string, or throws EBADF, ENOPROTOOPT, ETERM */
 Socket.prototype.getsockopt = function (level, option) {
     return this._protectArray(nn.Getsockopt(this.binding, level, option));

--- a/src/node_nanomsg.cc
+++ b/src/node_nanomsg.cc
@@ -131,9 +131,12 @@ NAN_METHOD(ZerocopySend) {
   int len = node::Buffer::Length(args[1]);
 
   void *msg = nn_allocmsg(len, 0);
-  memcpy(msg, node::Buffer::Data(args[1]), len);
-
-  NanReturnValue(NanNew<Number>(nn_send (s, &msg, NN_MSG, 0)));
+  if (!msg) {
+    return NanThrowError("zero-copy send failed: nn_allocmsg() returned NULL pointer");
+  } else {
+    memcpy(msg, node::Buffer::Data(args[1]), len);
+    NanReturnValue(NanNew<Number>(nn_send (s, &msg, NN_MSG, 0)));
+  }
 }
 
 NAN_METHOD(Recv) {

--- a/src/node_nanomsg.cc
+++ b/src/node_nanomsg.cc
@@ -117,11 +117,23 @@ NAN_METHOD(Send) {
 
   if (node::Buffer::HasInstance(args[1])) {
     NanReturnValue(NanNew<Number>(nn_send(
-        s, node::Buffer::Data(args[1]), node::Buffer::Length(args[1]), flags)));
+      s, node::Buffer::Data(args[1]), node::Buffer::Length(args[1]), flags)));
   } else {
     v8::String::Utf8Value str(args[1]->ToString());
     NanReturnValue(NanNew<Number>(nn_send(s, *str, str.length(), flags)));
   }
+}
+
+NAN_METHOD(ZerocopySend) {
+  NanScope();
+
+  int s = args[0]->Int32Value();
+  int len = node::Buffer::Length(args[1]);
+
+  void *msg = nn_allocmsg(len, 0);
+  memcpy(msg, node::Buffer::Data(args[1]), len);
+
+  NanReturnValue(NanNew<Number>(nn_send (s, &msg, NN_MSG, 0)));
 }
 
 NAN_METHOD(Recv) {
@@ -355,6 +367,7 @@ void InitAll(Handle<Object> exports) {
   EXPORT_METHOD(exports, Connect);
   EXPORT_METHOD(exports, Shutdown);
   EXPORT_METHOD(exports, Send);
+  EXPORT_METHOD(exports, ZerocopySend);
   EXPORT_METHOD(exports, Recv);
   EXPORT_METHOD(exports, Errno);
   EXPORT_METHOD(exports, PollSendSocket);

--- a/test/send.js
+++ b/test/send.js
@@ -118,3 +118,23 @@ test('send can take a number', function (t) {
   t.equal(bytes, msg.length);
 });
 
+test('zerocopy send', function (t) {
+  t.plan(2);
+
+  var pub = nano.socket('pub');
+  var sub = nano.socket('sub');
+  var addr = 'inproc://some_address';
+  var msg = Buffer(String(Math.pow(2, 42)));
+
+  pub.bind(addr);
+  sub.connect(addr);
+
+  sub.on('message', function (buf) {
+    t.equal(String(buf), String(msg));
+    pub.close();
+    sub.close();
+  });
+
+  var bytes = pub.zerocopySend(msg);
+  t.equal(bytes, msg.length);
+});


### PR DESCRIPTION
finally got around to fixing #79 here. @nickdesaulniers review?

We're already receiving messages in the zero-copy style. Originally I thought we needed to figure out a way to do zero-copy `nn_recv` but it was accomplished.

This PR adds a higher performance alternative send operation for outbound messages in zero-copy fashion. The API is straightforward and only accepts node buffers.

```js
socket.zerocopySend(buf);
```

if you're sending a string, you'll need do something like:
```js
var buf = Buffer('my string');
socket.zerocopySend(buf);
```

By creating this as a buffer-object-only API we're avoiding extra checks we do in the ordinary send operation, resulting in a measurable and consistent latency reduction across the board. As message size increases beyond half a megabyte, so do the benefits of this alternative send method. 

I'll add that while researching, it became clear to me that the purpose of exposing a zero-copy send method in libnanomsg is to allow custom memory allocations, i.e. something faster than `memcpy`.