### PR TITLE
add optional async callback param to connect()

### DIFF
--- a/examples/connect.js
+++ b/examples/connect.js
@@ -1,0 +1,10 @@
+// do an async connect before sending msg
+var nano = require('..');
+var pub = nano.socket('pub');
+var sub = nano.socket('sub');
+var addr = 'tcp://127.0.0.1:7789'
+pub.bind(addr);
+sub.pipe(process.stdout);
+var anotherRet = sub.connect(addr, function (ret) {
+  if (ret) pub.send('hello from nanomsg stream api\n');
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -245,8 +245,10 @@ Socket.prototype.bind = function (addr) {
   return this.bound[addr] = this._protect(nn.Bind( this.binding, addr ));
 }
 
-Socket.prototype.connect = function (addr) {
-  return this.connected[addr] = this._protect(nn.Connect( this.binding, addr ));
+Socket.prototype.connect = function (addr, fn) {
+  return this.connected[addr] = this._protect(
+    nn.Connect( this.binding, addr, fn || function(noop){} )
+  );
 }
 
 Socket.prototype.shutdown = function (addr) {

--- a/src/node_nanomsg.cc
+++ b/src/node_nanomsg.cc
@@ -81,10 +81,16 @@ NAN_METHOD(Bind) {
 }
 
 NAN_METHOD(Connect) {
+  Nan::Callback *callback = new Nan::Callback(info[2].As<Function>());
+
   int s = Nan::To<int>(info[0]).FromJust();
   String::Utf8Value addr(info[1]);
 
-  info.GetReturnValue().Set(Nan::New<Number>(nn_connect(s, *addr)));
+  int ret = nn_connect(s, *addr);
+  Local<Value> argv[] = { Nan::New<Number>(ret) };
+  info.GetReturnValue().Set(Nan::New<Number>(ret));
+
+  callback->Call(1, argv);
 }
 
 NAN_METHOD(Shutdown) {


### PR DESCRIPTION
review @nickdesaulniers ?

if we can add some optional async callbacks to nanomsg operations like this, then i think we can guarantee ordering and free us from excessive reliance on `setTimeout` in our tests. 
