### PR TITLE
OTHER_CFLAGS: the long overdue OSX/node-gyp epiphany

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,17 +13,6 @@
         ['use_system_libnanomsg=="false"', {
           'dependencies': [ 'deps/nanomsg.gyp:nanomsg', ],
         }],
-        ['OS=="mac"', {
-          'ldflags': [ '-L<(PRODUCT_DIR)' ],
-          'libraries': [ '-L<(PRODUCT_DIR)' ],
-          'xcode_settings': {
-            'OTHER_CPLUSPLUSFLAGS': [
-              '-fexceptions',
-              '-Wall',
-              '-Werror'
-            ]
-          }
-        }],
         ['OS=="linux" and use_system_libnanomsg=="true"', {
           'include_dirs+': [
             '<!@(pkg-config libnanomsg --cflags-only-I | sed s/-I//g)',

--- a/deps/common.gypi
+++ b/deps/common.gypi
@@ -1,7 +1,6 @@
 {
     # compiler settings to build the nanomsg library
     'defines': [
-        'NN_HAVE_GCC',
         'NN_HAVE_SOCKETPAIR',
         'NN_HAVE_SEMAPHORE',
         'NN_USE_PIPE',
@@ -118,7 +117,6 @@
     'direct_dependent_settings': {
         # build nanomsg hub with same compiler flags as the library
         'defines': [
-            'NN_HAVE_GCC',
             'NN_HAVE_SOCKETPAIR',
             'NN_HAVE_SEMAPHORE',
             'NN_USE_PIPE',

--- a/deps/linux.gypi
+++ b/deps/linux.gypi
@@ -1,6 +1,7 @@
 {
     # compiler settings to build the nanomsg library
     'defines': [
+        'NN_HAVE_GCC',
         'NN_HAVE_LINUX',
         'NN_USE_EPOLL',
         'NN_HAVE_PIPE',
@@ -13,6 +14,7 @@
     ],
     'direct_dependent_settings': {
         'defines': [
+            'NN_HAVE_GCC',
             'NN_HAVE_LINUX',
             'NN_USE_EPOLL',
             'NN_HAVE_PIPE',

--- a/deps/macosx.gypi
+++ b/deps/macosx.gypi
@@ -1,5 +1,12 @@
 {
     # compiler settings to build the nanomsg library
+    # osx ignores 'cflags' and 'CFLAGS' given to .gyp when compiling the lib
+    # OTHER_CFLAGS is the trick and must be in 'xcode_settings'
+    'xcode_settings': {
+        'OTHER_CFLAGS': [
+            '-Wno-unused',
+        ],
+    },
     'defines': [
         'NN_HAVE_CLANG',
         'NN_HAVE_OSX',


### PR DESCRIPTION
finally figured out stuff related to #109 https://github.com/nodejs/node-gyp/issues/594

:nut_and_bolt: :date: :nut_and_bolt: :nut_and_bolt:

OK here's the trick to pass real `cflags=` to node-gyp compiler toolchain from OSX



npm installing node-nanomsg on OSX historically generates warnings, like these unused variables:

```go
In file included from ../deps/nanomsg/src/aio/poller.c:32:
../deps/nanomsg/src/aio/poller_kqueue.inc:66:9: warning: unused variable 'rc' [-Wunused-variable]
    int rc;
        ^
../deps/nanomsg/src/aio/poller_kqueue.inc:90:9: warning: unused variable 'fd' [-Wunused-variable]
    int fd = hndl->fd;
        ^
2 warnings generated.
```

we can add `-Wno-unused` to the arg list for evaluation on gyp targets by listing *`OTHER_CFLAGS` under `xcode_settings`*. 

### `cflags=` doesn't work outside `xcode_settings`
Only the super magically reserved word: *`OTHER_CFLAGS`* works, so `cflags` and `CFLAGS` won't cut it

also, when i was fooling around in our `.gyp` stuff this morning, i noticed:
* the `'OS=="MAC"` [condition in `binding.gyp`](https://github.com/nickdesaulniers/node-nanomsg/blob/master/binding.gyp#L16-L26) is useless (condition in 2nd target), let's get rid of it
* macro definition `NN_HAVE_GCC` isn't the best assumption for all OS, so moved to linux.gypi
* applied the magic in macosx.gypi to finally shut clang up! :boom: :bomb: :boom: