### PR TITLE
update system install option

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -15,10 +15,22 @@
         }],
         ['OS=="linux" and use_system_libnanomsg=="true"', {
           'include_dirs+': [
-            '<!@(pkg-config libnanomsg --cflags-only-I | sed s/-I//g)',
+            '<!@(pkg-config nanomsg --cflags-only-I | sed s/-I//g)/nanomsg  || echo "")',
+            '<!@(pkg-config libnanomsg --cflags | sed s/-I//g || echo "")',
           ],
           'libraries': [
-            '<!@(pkg-config libnanomsg --libs)',
+            '<!@(pkg-config nanomsg --libs || echo "")',
+            '<!@(pkg-config libnanomsg --libs || echo "")',
+          ],
+        }],
+        ['OS=="mac" and use_system_libnanomsg=="true"', {
+          'include_dirs+': [
+            '<!@(pkg-config libnanomsg --cflags | sed s/-I//g || echo "")',
+            '<!@(pkg-config nanomsg --cflags | sed s/-I//g || echo "")',
+          ],
+          'libraries': [
+            '<!@(pkg-config libnanomsg --libs || echo "")',
+            '<!@(pkg-config nanomsg --libs || echo "")',
           ],
         }],
         ['OS=="win"', {

--- a/src/node_nanomsg.cc
+++ b/src/node_nanomsg.cc
@@ -3,18 +3,18 @@
 #include "node_pointer.h"
 
 #include <nn.h>
-#include <protocol.h>
+
+#include <inproc.h>
+#include <ipc.h>
+#include <tcp.h>
+#include <ws.h>
+
 #include <pubsub.h>
 #include <pipeline.h>
 #include <bus.h>
 #include <pair.h>
 #include <reqrep.h>
 #include <survey.h>
-#include <inproc.h>
-#include <ipc.h>
-#include <tcp.h>
-#include <transport.h>
-#include <ws.h>
 
 using v8::Array;
 using v8::Function;


### PR DESCRIPTION
fixes #157 for libnanomsg >= 1.0

BTW this `--use_system_libnanomsg` flag is supported on linux only

do we want to enable this for osx? could add that here while we're at it.

cc for review: @nickdesaulniers, @deepakprabhakara 