### PR TITLE
fix: not subscribed message cause stream end

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -176,7 +176,10 @@ Socket.prototype._send = function (msg, flags) {
 };
 
 Socket.prototype._receive = function () {
-  if (this.closed) return null;
+  if (this.closed){
+    this.push(null);
+    return;
+  }
 
   var msg = nn.Recv(this.binding, nn.NN_DONTWAIT);
 
@@ -184,15 +187,15 @@ Socket.prototype._receive = function () {
         if(msg < 0 && nn.Errno() === nn.EFSM) {
             this._stopPollSend();
             this._stopPollReceive();
-            return null;
+            return;
         }
     } else if(this.type === 'rep') {
       this._stopPollReceive();
     }
-  if (msg === -1) return null;
+  if (msg === -1) return;
 
   if (this.restore && typeof this.restore === 'function') msg = this.restore(msg);
-  return msg;
+  this.push(msg);
 };
 
 Socket.prototype._startPollSend = function () {
@@ -206,7 +209,7 @@ Socket.prototype._startPollSend = function () {
 Socket.prototype._startPollReceive = function () {
   if (!this._pollReceive) {
     this._pollReceive = nn.PollReceiveSocket(this.binding, function (events) {
-      if (events) this.push(this._receive());
+      if (events) this._receive();
     }.bind(this));
   }
 }


### PR DESCRIPTION
sub.chan(['a']);
pub.send('b');//Socket._receive() return null cause Socket._startPollReceive() this.push(null)
pub.send('a');