### PR TITLE
fix build on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nanomsg for node
 
-[![Build Status](https://travis-ci.org/nickdesaulniers/node-nanomsg.svg?branch=master)](https://travis-ci.org/nickdesaulniers/node-nanomsg) [![Build status](https://ci.appveyor.com/api/projects/status/07j7o9juuktas2uk)](https://ci.appveyor.com/project/tcr/node-nanomsg)
+[![Build Status](https://travis-ci.org/nickdesaulniers/node-nanomsg.svg?branch=master)](https://travis-ci.org/nickdesaulniers/node-nanomsg) [![Build status](https://ci.appveyor.com/api/projects/status/og7qumak4khcne8u?svg=true)](https://ci.appveyor.com/project/reqshark/node-nanomsg)
 
 ### install:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,5 @@ install:
 
 build_script:
   - git submodule update --init
+  - npm -g install npm@latest
   - npm install
-
-platforms:
-  - x32

--- a/deps/win.gypi
+++ b/deps/win.gypi
@@ -19,6 +19,21 @@
             '-ladvapi32',
         ],
     },
+    'direct_dependent_settings': {
+        # build nanomsg hub with same compiler flags as the library
+        'defines': [
+            '_WINDOWS',
+            '_CRT_SECURE_NO_WARNINGS',
+            'NN_HAVE_WINDOWS',
+            'WIN32',
+            '_WIN32',
+            'NN_USE_LITERAL_IFADDR',
+            'NN_SHARED_LIB',
+            'NN_HAVE_STDINT',
+            'NN_HAVE_WINSOCK',
+            'NN_USE_WINSOCK',
+        ],
+    },
     'target_defaults': {
         'default_configuration': 'Debug',
         'configurations': {


### PR DESCRIPTION
per #164, we have a windows build regression after `v3.2.0`, traced to a commit where i removed `direct_dependent_settings` for windows: 8614e528ef4ffb19fab2eeb6e101296cede681aa

This PR fixes windows by reintroducing those `direct_dependent_settings` in its gyp file. 

Also updating our appveyor CI so we can know about any build issues on windows in the future:  https://ci.appveyor.com/project/reqshark/node-nanomsg

@nickdesaulniers, review?