### PR TITLE
add asan build support #151

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,3 +420,7 @@ WIP
 ## license
 
 MIT
+
+## memory leak hunting
+`npm i --asan=true`
+

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,6 +1,7 @@
 {
   'variables': {
     'use_system_libnanomsg%': 'false',
+    'asan': 'false',
   },
   'targets': [
     {
@@ -32,6 +33,13 @@
             '<!@(pkg-config libnanomsg --libs || echo "")',
             '<!@(pkg-config nanomsg --libs || echo "")',
           ],
+        }],
+        ['OS=="mac" and asan=="true"', {
+          'xcode_settings': {
+            'OTHER_LDFLAGS': [
+              '-fsanitize=address'
+            ]
+          }
         }],
         ['OS=="win"', {
           'cflags': [ '-Wall -Werror -Wno-unused' ],

--- a/deps/macosx.gypi
+++ b/deps/macosx.gypi
@@ -7,6 +7,15 @@
             '-Wno-unused',
         ],
     },
+    'conditions': [
+        ['asan=="true"', {
+            'xcode_settings': {
+                'OTHER_CFLAGS': [
+                    '-fsanitize=address'
+                ]
+            }
+        }]
+    ],
     'defines': [
         'NN_HAVE_SOCKETPAIR',
         'NN_HAVE_SEMAPHORE',


### PR DESCRIPTION
build with `npm i --asan=true`.  This will use a build that links in
asan at runtime.

The odd split in .gyp files exists because we want to compile nanomsg
with asan instrumentation, but when we link our node_namomsg.node shared
object we want to remind gyp to link asan's runtime library.

This can likely also be done for Linux, but I haven't tested.

Also, we segfault off the bat with this.  I don't have time to look into
it, but at least it builds correctly.