### PR TITLE
fix memory leak(#151)

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ Issues and pull requests welcome!
 <tr><th align="left">Nick Desaulniers</th><td><a href="https://github.com/nickdesaulniers">GitHub/nickdesaulniers</a></td><td><a href="http://twitter.com/LostOracle">Twitter/@LostOracle</a></td></tr>
 <tr><th align="left">Tim Cameron Ryan</th><td><a href="https://github.com/tcr">GitHub/tcr</a></td><td><a href="http://twitter.com/timcameronryan">Twitter/@timcameronryan</a></td></tr>
 <tr><th align="left">Trygve Lie</th><td><a href="https://github.com/trygve-lie">GitHub/trygve-lie</a></td><td><a href="http://twitter.com/trygve_lie">Twitter/@trygve_lie</a></td></tr>
+<tr><th align="left">m-ohuchi</th><td><a href="https://github.com/m-ohuchi">GitHub/m-ohuchi</a></td><td>-</td></tr>
 </tbody></table>
 
 ## formatting

--- a/README.md
+++ b/README.md
@@ -403,11 +403,11 @@ Issues and pull requests welcome!
 <tr><th align="left">Bent Cardan</th><td><a href="https://github.com/reqshark/">GitHub/reqshark</a></td><td><a href="http://twitter.com/rekshark">Twitter/@rekshark</a></td></tr>
 <tr><th align="left">Deepak Prabhakara</th><td><a href="https://github.com/deepakprabhakara/">GitHub/deepakprabhakara</a></td><td><a href="http://twitter.com/deepakprab">Twitter/@deepakprab</a></td></tr>
 <tr><th align="left">Flynn Joffray</th><td><a href="https://github.com/nucleardreamer/">GitHub/nucleardreamer</a></td><td><a href="http://twitter.com/nucleardreamer">Twitter/@nucleardreamer</a></td></tr>
+<tr><th align="left">m-ohuchi</th><td><a href="https://github.com/m-ohuchi">GitHub/m-ohuchi</a></td><td>-</td></tr>
 <tr><th align="left">Michele Comignano</th><td><a href="https://github.com/comick">GitHub/comick</a></td><td>-</td></tr>
 <tr><th align="left">Nick Desaulniers</th><td><a href="https://github.com/nickdesaulniers">GitHub/nickdesaulniers</a></td><td><a href="http://twitter.com/LostOracle">Twitter/@LostOracle</a></td></tr>
 <tr><th align="left">Tim Cameron Ryan</th><td><a href="https://github.com/tcr">GitHub/tcr</a></td><td><a href="http://twitter.com/timcameronryan">Twitter/@timcameronryan</a></td></tr>
 <tr><th align="left">Trygve Lie</th><td><a href="https://github.com/trygve-lie">GitHub/trygve-lie</a></td><td><a href="http://twitter.com/trygve_lie">Twitter/@trygve_lie</a></td></tr>
-<tr><th align="left">m-ohuchi</th><td><a href="https://github.com/m-ohuchi">GitHub/m-ohuchi</a></td><td>-</td></tr>
 </tbody></table>
 
 ## formatting

--- a/src/node_nanomsg.cc
+++ b/src/node_nanomsg.cc
@@ -113,7 +113,7 @@ NAN_METHOD(Send) {
 
 void fcb(char *data, void *hint) {
   nn_freemsg(data);
-  (void) hint;
+  (void)hint;
 }
 
 NAN_METHOD(Recv) {
@@ -194,8 +194,8 @@ NAN_METHOD(Err) {
 void NanomsgReadable(uv_poll_t *req, int status, int events) {
   Nan::HandleScope scope;
 
-  nanomsg_socket_t *context;
-  context = reinterpret_cast<nanomsg_socket_t *>(req);
+  nanomsg_socket_s *context;
+  context = reinterpret_cast<nanomsg_socket_s *>(req);
 
   if (events & UV_READABLE) {
     Local<Value> argv[] = { Nan::New<Number>(events) };
@@ -203,14 +203,60 @@ void NanomsgReadable(uv_poll_t *req, int status, int events) {
   }
 }
 
+// release memory of given context object when this function is called twice
+// with the same context argument
+static void free_context(nanomsg_socket_s *context) {
+  uv_mutex_lock(&context->free_mutex);
+  if (context->free_called) {
+    delete (context->callback);
+    context->callback = NULL;
+
+    // forget poll_handle.data because it indicate to the context itself.
+    // otherwise free operation will try to release the memory of the context
+    // twice.
+    context->poll_handle.data = NULL;
+
+    uv_mutex_destroy(&context->close_mutex);
+
+    uv_mutex_unlock(&context->free_mutex);
+    uv_mutex_destroy(&context->free_mutex);
+    free(context);
+  } else {
+    context->free_called = true;
+    uv_mutex_unlock(&context->free_mutex);
+  }
+}
+
+/*
+ * Called when the "pointer" is garbage collected.
+ */
+
+// this function is called asynchronously at destructor when garbage collection
+// is executed
+static void wrap_pointer_cb(char *data, void *hint) {
+  nanomsg_socket_s *context = reinterpret_cast<nanomsg_socket_s *>(data);
+
+  // free context object if close_cb of uv_close has been called already
+  free_context(context);
+}
+
+/*
+ * Wraps "ptr" into a new SlowBuffer instance with size "length".
+ */
+
+static v8::Local<v8::Value> WrapPointer(void *ptr, size_t length) {
+  return Nan::NewBuffer(static_cast<char *>(ptr), length, wrap_pointer_cb, 0)
+      .ToLocalChecked();
+}
+
 NAN_METHOD(PollSendSocket) {
   int s = Nan::To<int>(info[0]).FromJust();
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
 
-  nanomsg_socket_t *context;
+  nanomsg_socket_s *context;
   size_t siz = sizeof(uv_os_sock_t);
 
-  context = reinterpret_cast<nanomsg_socket_t *>(calloc(1, sizeof *context));
+  context = reinterpret_cast<nanomsg_socket_s *>(calloc(1, sizeof *context));
   context->poll_handle.data = context;
   context->callback = callback;
 
@@ -234,10 +280,10 @@ NAN_METHOD(PollReceiveSocket) {
   int s = Nan::To<int>(info[0]).FromJust();
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
 
-  nanomsg_socket_t *context;
+  nanomsg_socket_s *context;
   size_t siz = sizeof(uv_os_sock_t);
 
-  context = reinterpret_cast<nanomsg_socket_t *>(calloc(1, sizeof *context));
+  context = reinterpret_cast<nanomsg_socket_s *>(calloc(1, sizeof *context));
   context->poll_handle.data = context;
   context->callback = callback;
 
@@ -257,28 +303,49 @@ NAN_METHOD(PollReceiveSocket) {
   }
 }
 
+/*
+ * Unwraps Buffer instance "buffer" to a C `char *` (no offset applied).
+ */
+
+static char *UnwrapPointer(v8::Local<v8::Value> buffer) {
+  if (node::Buffer::HasInstance(buffer)) {
+    return node::Buffer::Data(buffer.As<v8::Object>());
+  } else {
+    return 0;
+  }
+}
+
+/**
+ * Templated version of UnwrapPointer that does a reinterpret_cast() on the
+ * pointer before returning it.
+ */
+
+template <typename Type>
+static Type UnwrapPointer(v8::Local<v8::Value> buffer) {
+  return reinterpret_cast<Type>(UnwrapPointer(buffer));
+}
+
 // this function is called asynchronously after uv_close function call
-inline void close_cb(uv_handle_t *handle){
-  nanomsg_socket_t *context = reinterpret_cast<nanomsg_socket_t *>(handle->data);
+void close_cb(uv_handle_t *handle) {
+  nanomsg_socket_s *context =
+      reinterpret_cast<nanomsg_socket_s *>(handle->data);
 
   // free context object if it's destructor has been called already
   free_context(context);
 }
 
 NAN_METHOD(PollStop) {
-  nanomsg_socket_t *context = UnwrapPointer<nanomsg_socket_t *>(info[0]);
+  nanomsg_socket_s *context = UnwrapPointer<nanomsg_socket_s *>(info[0]);
 
-  // the mutex guard is necessary for the case when asynchronous flush ends and synchronous close are called at the same time.
+  // the mutex guard is necessary for the case when asynchronous flush ends and
+  // synchronous close are called at the same time.
   uv_mutex_lock(&context->close_mutex);
-  if(context->close_called == true){
-    info.GetReturnValue().Set(Nan::New<Number>(0));
-    uv_mutex_unlock(&context->close_mutex);    
-  }else{
+  if (context->close_called != true) {
     context->close_called = true;
-    uv_close((uv_handle_t*) &context->poll_handle, &close_cb);
-    info.GetReturnValue().Set(Nan::New<Number>(0));
-    uv_mutex_unlock(&context->close_mutex);
+    uv_close((uv_handle_t *)&context->poll_handle, &close_cb);
   }
+  info.GetReturnValue().Set(Nan::New<Number>(0));
+  uv_mutex_unlock(&context->close_mutex);
 }
 
 class NanomsgDeviceWorker : public Nan::AsyncWorker {

--- a/src/node_pointer.h
+++ b/src/node_pointer.h
@@ -5,100 +5,13 @@
 
 #include <nan.h>
 
-typedef struct nanomsg_socket_s {
+struct nanomsg_socket_s {
   uv_poll_t poll_handle;
   uv_os_sock_t sockfd;
   Nan::Callback *callback;
 
   uv_mutex_t close_mutex;
-  bool close_called;
-
   uv_mutex_t free_mutex;
+  bool close_called;
   bool free_called;
-} nanomsg_socket_t;
-
-// release memory of given context object when this function is called twice with the same context argument 
-inline void free_context(nanomsg_socket_t *context){
-  uv_mutex_lock(&context->free_mutex);
-  if(context->free_called){
-
-    delete(context->callback); 
-    context->callback = NULL;
-
-    // forget poll_handle.data because it indicate to the context itself.
-    // otherwise free operation will try to release the memory of the context twice.
-    context->poll_handle.data = NULL;
-
-    uv_mutex_destroy(&context->close_mutex);
-
-    uv_mutex_unlock(&context->free_mutex);
-    uv_mutex_destroy(&context->free_mutex);
-    free(context);
-  }else{
-    context->free_called = true;
-    uv_mutex_unlock(&context->free_mutex);
-  }
-}
-
-/*
- * Called when the "pointer" is garbage collected.
- */
-
-// this function is called asynchronously at destructor when garbage collection is executed
-inline static void wrap_pointer_cb(char *data, void *hint) {
-  nanomsg_socket_t *context = reinterpret_cast<nanomsg_socket_t*>(data);
-
-  // free context object if close_cb of uv_close has been called already 
-  free_context(context);
-}
-
-/*
- * Wraps "ptr" into a new SlowBuffer instance with size "length".
- */
-
-inline static v8::Local<v8::Value> WrapPointer(void *ptr, size_t length) {
-  return Nan::NewBuffer(static_cast<char *>(ptr), length, wrap_pointer_cb, 0)
-      .ToLocalChecked();
-}
-
-/*
- * Wraps "ptr" into a new SlowBuffer instance with length 0.
- */
-
-inline static v8::Local<v8::Value> WrapPointer(void *ptr) {
-  return WrapPointer(ptr, 0);
-}
-
-/*
- * Unwraps Buffer instance "buffer" to a C `char *` with the offset specified.
- */
-
-inline static char *UnwrapPointer(v8::Local<v8::Value> buffer, int64_t offset) {
-  if (node::Buffer::HasInstance(buffer)) {
-    return node::Buffer::Data(buffer.As<v8::Object>()) + offset;
-  } else {
-    return 0;
-  }
-}
-
-/*
- * Unwraps Buffer instance "buffer" to a C `char *` (no offset applied).
- */
-
-inline static char *UnwrapPointer(v8::Local<v8::Value> buffer) {
-  if (node::Buffer::HasInstance(buffer)) {
-    return node::Buffer::Data(buffer.As<v8::Object>());
-  } else {
-    return 0;
-  }
-}
-
-/**
- * Templated version of UnwrapPointer that does a reinterpret_cast() on the
- * pointer before returning it.
- */
-
-template <typename Type>
-inline static Type UnwrapPointer(v8::Local<v8::Value> buffer) {
-  return reinterpret_cast<Type>(UnwrapPointer(buffer));
-}
+};


### PR DESCRIPTION
#151 

I could fix this memory leak. Please review and improve my code if necessary(Especially I think the timing to free the memory is unusual). 
With this fix, I make sure the memory leak is disappeared using the test tool by @deepakprabhakara as follows:

result of original code

    $ ./node --trace_gc --max_executable_size=8 nano.js 
    [8643:0xa09a738]       16 ms: Scavenge 1.7 (2.5) -> 1.6 (3.5) MB, 1.8 / 0.0 ms [allocation failure].
    [8643:0xa09a738]       19 ms: Scavenge 1.6 (3.5) -> 1.6 (4.5) MB, 1.7 / 0.0 ms [allocation failure].
    ...
    [8643:0xa09a738]  1051936 ms: Mark-sweep 23.4 (27.5) -> 23.2 (27.5) MB, 34.1 / 3.0 ms (+ 110.5 ms in 55 steps since start of marking, biggest step 9.4 ms) [GC interrupt] [GC in old space requested].
    -------- <LEAK> -------
    {"growth":15882648,"reason":"heap growth over 5 consecutive GCs (13m 8s) - 69.2 mb/hr"}
    -------- </LEAK> -------
    ...
    [8643:0xa09a738]  4728198 ms: Mark-sweep 94.0 (100.5) -> 93.1 (100.5) MB, 155.2 / 6.5 ms (+ 355.3 ms in 166 steps since start of marking, biggest step 35.9 ms) [GC interrupt] [GC in old space requested].
    -------- <LEAK> -------
    {"growth":17302520,"reason":"heap growth over 5 consecutive GCs (15m 9s) - 65.35 mb/hr"}
    -------- </LEAK> -------
    ...
    (the heap allocation size keep increasing.)

result of fixed code

    $ ./node --trace_gc --max_executable_size=8 nano.js
    [9757:0xa8ac738]       16 ms: Scavenge 1.7 (2.5) -> 1.6 (3.5) MB, 1.2 / 0.0 ms [allocation failure].
    [9757:0xa8ac738]       17 ms: Scavenge 1.6 (3.5) -> 1.6 (4.5) MB, 1.1 / 0.0 ms [allocation failure].
    ...
    [9757:0xa8ac738]  1053811 ms: Scavenge 5.7 (8.5) -> 4.9 (8.5) MB, 3.5 / 1.1 ms [allocation failure].
    ...
    [9757:0xa8ac738]  2230825 ms: Scavenge 8.9 (11.5) -> 8.1 (11.5) MB, 6.3 / 1.5 ms [allocation failure].
    [9757:0xa8ac738]  2238570 ms: Mark-sweep 8.9 (11.5) -> 3.2 (8.5) MB, 13.0 / 1.3 ms [allocation failure] [promotion limit reached].
    [9757:0xa8ac738]  2245874 ms: Scavenge 4.0 (8.5) -> 3.2 (8.5) MB, 2.9 / 1.1 ms [allocation failure].
    ...
    [9757:0xa8ac738]  5207302 ms: Scavenge 12.1 (15.5) -> 11.3 (15.5) MB, 6.7 / 1.4 ms [allocation failure].
    [9757:0xa8ac738]  5215005 ms: Mark-sweep 12.1 (15.5) -> 3.1 (8.5) MB, 9.9 / 1.2 ms (+ 8.5 ms in 18 steps since start of marking, biggest step 2.1 ms) [GC interrupt] [GC in old space requested].
    ...
    (the heap allocation size is reset to 3.1~3.2 MB every time when the Mark-sweep GC occurred.)

 
Add codes to free context to fix the memory leak discussed at #151.
- Replace uv_poll_stop with uv_close to unref the poll_handler
- Add mutexs to PollStop to guard asynchronous invocation by the end
  of flush operation and synchronous invocation by close operation
- Call free(context) to free memory of struct context
- Execute above free operation when they are called twice using mutexes
  to guarantee the memory is to be freed at last. Because
  wrap_pointer_cb called by GC and the latter part of uv_close
  (and close_cb) will be called asynchronously and disorderly.