### PR TITLE
add dontwait option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ nano.socket('bus', { raw: true } );
 * `'rcvmaxsize'` *(Number, default: `false`)*: see [`socket.rcvmaxsize(size)`](https://github.com/nickdesaulniers/node-nanomsg#socketrcvmaxsizesize)
 * `'chan'` *(Array, default: `['']`)*: see [`socket.chan(Array)`](https://github.com/nickdesaulniers/node-nanomsg#socketchanarray)
 * `'wsopt'` *(String, default: `'binary'`)*: see [`socket.wsopt(str)`](https://github.com/nickdesaulniers/node-nanomsg#socketwsoptstr)
+* `'dontwait'` *(Number, default: `'1'`)*: see [`socket.dontwait(n)`](https://github.com/nickdesaulniers/node-nanomsg#socketdontwaitn)
 
 ### socket.shutdown(address)
 
@@ -334,6 +335,23 @@ console.log(socket.wsopt()); // 'text'
 ```
 
 If you are implementing nanomsg websockets in the browser, please carefully review the spec: https://raw.githubusercontent.com/nanomsg/nanomsg/master/rfc/sp-websocket-mapping-01.txt
+
+### socket.dontwait(n)
+
+*(Function, param: Number, one or zero, default: `1`, except PUSH sockets)*: Sets the NN_DONTWAIT flag, specifying that the operation should be performed in non-blocking mode,
+
+* `1` for non-blocking mode
+* `0` for blocking mode
+
+Pass no parameter for the socket's current mode.
+
+```js
+socket.dontwait(0);
+console.log(socket.dontwait()); // 0
+
+// or set when socket is started:
+require('nanomsg').socket('pub', { dontwait: 0 });
+```
 
 # test
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ nano.socket('bus', { raw: true } );
 * `'rcvmaxsize'` *(Number, default: `false`)*: see [`socket.rcvmaxsize(size)`](https://github.com/nickdesaulniers/node-nanomsg#socketrcvmaxsizesize)
 * `'chan'` *(Array, default: `['']`)*: see [`socket.chan(Array)`](https://github.com/nickdesaulniers/node-nanomsg#socketchanarray)
 * `'wsopt'` *(String, default: `'binary'`)*: see [`socket.wsopt(str)`](https://github.com/nickdesaulniers/node-nanomsg#socketwsoptstr)
-* `'dontwait'` *(Number, default: `'1'`)*: see [`socket.dontwait(n)`](https://github.com/nickdesaulniers/node-nanomsg#socketdontwaitn)
+* `'dontwait'` *(boolean, default: `true`)*: see [`socket.dontwait(boolean)`](https://github.com/nickdesaulniers/node-nanomsg#socketdontwaitboolean)
 
 ### socket.shutdown(address)
 
@@ -336,21 +336,21 @@ console.log(socket.wsopt()); // 'text'
 
 If you are implementing nanomsg websockets in the browser, please carefully review the spec: https://raw.githubusercontent.com/nanomsg/nanomsg/master/rfc/sp-websocket-mapping-01.txt
 
-### socket.dontwait(n)
+### socket.dontwait(boolean)
 
-*(Function, param: Number, one or zero, default: `1`, except PUSH sockets)*: Sets the NN_DONTWAIT flag, specifying that the operation should be performed in non-blocking mode,
+*(Function, param: Boolean, default: `true`, except PUSH sockets)*: Sets the NN_DONTWAIT flag, specifying that the operation should be performed in non-blocking mode,
 
-* `1` for non-blocking mode
-* `0` for blocking mode
+* `true` for non-blocking mode
+* `false` for blocking mode
 
 Pass no parameter for the socket's current mode.
 
 ```js
-socket.dontwait(0);
-console.log(socket.dontwait()); // 0
+socket.dontwait(false);
+console.log(socket.dontwait()); // false
 
 // or set when socket is started:
-require('nanomsg').socket('pub', { dontwait: 0 });
+require('nanomsg').socket('pub', { dontwait: false });
 ```
 
 # test

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,8 @@ function Socket (type, opts) {
             this.protocol = nn.NN_PUSH;
             this.sender = true;
             this.receiver = false;
-            opts.dontwait = opts.dontwait || 0;
+            // nndontwait otherwise defaults true, PUSH socket default is false
+            opts.dontwait = opts.dontwait || false;
             break;
 
         case 'pull':
@@ -104,7 +105,7 @@ function Socket (type, opts) {
   this.queue = [];
 
   /* async I/O option */
-  this.nndontwait = 'dontwait' in opts ? opts.dontwait : nn.NN_DONTWAIT;
+  this.dontwait( 'dontwait' in opts ? opts.dontwait : true );
 
   /*  subscription filter control */
   this.channels     = {};
@@ -463,15 +464,17 @@ Socket.prototype.rmchan     = function() {
   };
 }
 
-Socket.prototype.dontwait   = function (n) {
+Socket.prototype.dontwait   = function (bool) {
   if ( arguments.length ) {
-    if (typeof n !== 'number' || n > 1 || n < 0) {
-      throw new TypeError('dontwait option must be either 1 or 0')
+    if(bool){
+      this.nndontwait = nn.NN_DONTWAIT;
+      return true;
+    } else {
+      this.nndontwait = 0;
+      return false;
     }
-    this.nndontwait = n;
-    return true;
   } else {
-    return this.nndontwait;
+    return Boolean(this.nndontwait);
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,7 @@ function Socket (type, opts) {
   this.queue = [];
 
   /* async I/O option */
-  this.dontwait( 'dontwait' in opts ? opts.dontwait : true );
+  this.dontwait('dontwait' in opts ? opts.dontwait : true);
 
   /*  subscription filter control */
   this.channels     = {};
@@ -465,7 +465,7 @@ Socket.prototype.rmchan     = function() {
 }
 
 Socket.prototype.dontwait   = function (bool) {
-  if ( arguments.length ) {
+  if (arguments.length) {
     if(bool){
       this.nndontwait = nn.NN_DONTWAIT;
       return true;

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,7 @@ function Socket (type, opts) {
             this.protocol = nn.NN_PUSH;
             this.sender = true;
             this.receiver = false;
+            opts.dontwait = opts.dontwait || 0;
             break;
 
         case 'pull':
@@ -101,6 +102,9 @@ function Socket (type, opts) {
   this.bound = {};
   this.connected = {};
   this.queue = [];
+
+  /* async I/O option */
+  this.nndontwait = 'dontwait' in opts ? opts.dontwait : nn.NN_DONTWAIT;
 
   /*  subscription filter control */
   this.channels     = {};
@@ -181,7 +185,7 @@ Socket.prototype._receive = function () {
     return;
   }
 
-  var msg = nn.Recv(this.binding, nn.NN_DONTWAIT);
+  var msg = nn.Recv(this.binding, this.nndontwait);
 
   if(this.type === 'surveyor') {
         if(msg < 0 && nn.Errno() === nn.EFSM) {
@@ -236,7 +240,7 @@ Socket.prototype._register = function(chan){
 };
 
 Socket.prototype._write = function(buf, _, cb){
-  this.send(buf, nn.NN_DONTWAIT);
+  this.send(buf, this.nndontwait);
   cb();
 }
 
@@ -457,6 +461,18 @@ Socket.prototype.rmchan     = function() {
       }
     }
   };
+}
+
+Socket.prototype.dontwait   = function (n) {
+  if ( arguments.length ) {
+    if (typeof n !== 'number' || n > 1 || n < 0) {
+      throw new TypeError('dontwait option must be either 1 or 0')
+    }
+    this.nndontwait = n;
+    return true;
+  } else {
+    return this.nndontwait;
+  }
 }
 
 /**

--- a/test/pushstress.js
+++ b/test/pushstress.js
@@ -1,0 +1,48 @@
+var nano = require('..');
+var test = require('tape');
+
+test('push stress', function (t) {
+  t.plan(2);
+  var i = 9999;
+  var pull = nano.socket('pull', {encoding:'utf8'} );
+  var push = nano.socket('push');
+  var addr = 'tcp://127.0.0.1:7799';
+  var msg = 'hello from nanomsg stream api'
+  pull.connect(addr);
+  push.bind(addr);
+  pull.on('data', function(data){
+    if (data !== msg)
+      throw new Error('assertion failed');
+    if (++i === 9998) {
+      t.equal(push.nndontwait, 0);
+      t.equal(this.nndontwait, 1);
+      push.close();
+      pull.close();
+    }
+  });
+  while (i--)
+    push.send(msg);
+});
+
+test('set dontwait options', function (t) {
+  t.plan(2);
+  var i = 9;
+  var pull = nano.socket('pull', {encoding:'utf8', dontwait:0} );
+  var push = nano.socket('push', {dontwait:1});
+  var addr = 'tcp://127.0.0.1:7899';
+  var msg = 'hello from nanomsg stream api'
+  pull.connect(addr);
+  push.bind(addr);
+  pull.on('data', function(data){
+    if (data !== msg)
+      throw new Error('assertion failed');
+    if (++i === 8) {
+      t.equal(push.nndontwait, 1);
+      t.equal(this.nndontwait, 0);
+      push.close();
+      pull.close();
+    }
+  });
+  while (i--)
+    push.send(msg);
+});

--- a/test/pushstress.js
+++ b/test/pushstress.js
@@ -2,7 +2,7 @@ var nano = require('..');
 var test = require('tape');
 
 test('push stress', function (t) {
-  t.plan(2);
+  t.plan(4);
   var i = 9999;
   var pull = nano.socket('pull', {encoding:'utf8'} );
   var push = nano.socket('push');
@@ -14,8 +14,10 @@ test('push stress', function (t) {
     if (data !== msg)
       throw new Error('assertion failed');
     if (++i === 9998) {
+      t.equal(push.dontwait(), false);
       t.equal(push.nndontwait, 0);
-      t.equal(this.nndontwait, 1);
+      t.equal(pull.dontwait(), true);
+      t.equal(pull.nndontwait, 1);
       push.close();
       pull.close();
     }
@@ -24,11 +26,11 @@ test('push stress', function (t) {
     push.send(msg);
 });
 
-test('set dontwait options', function (t) {
-  t.plan(2);
+test('set dontwait at init and verify sockopt results', function (t) {
+  t.plan(4);
   var i = 9;
-  var pull = nano.socket('pull', {encoding:'utf8', dontwait:0} );
-  var push = nano.socket('push', {dontwait:1});
+  var pull = nano.socket('pull', {encoding:'utf8', dontwait: false} );
+  var push = nano.socket('push', {dontwait: true});
   var addr = 'tcp://127.0.0.1:7899';
   var msg = 'hello from nanomsg stream api'
   pull.connect(addr);
@@ -37,8 +39,12 @@ test('set dontwait options', function (t) {
     if (data !== msg)
       throw new Error('assertion failed');
     if (++i === 8) {
+      // check nndontwait values set at init and compare assumption w/ sockopt
+      t.equal(pull.nndontwait, 0);
+      t.equal(pull.dontwait(), false);
+
       t.equal(push.nndontwait, 1);
-      t.equal(this.nndontwait, 0);
+      t.equal(push.dontwait(), true);
       push.close();
       pull.close();
     }

--- a/test/sockoptapi.js
+++ b/test/sockoptapi.js
@@ -76,15 +76,15 @@ test('sockopt api methods', function(t){
   t.equal( sock.wsopt(), 'binary', 'sock.wsopt() gets: binary');
 
   //get default dontwait option for push
-  t.equal( sock.dontwait(), 0, 'sock.dontwait() gets: 0');
+  t.equal( sock.dontwait(), false, 'sock.dontwait() gets: false');
 
   //set dontwait option
-  t.equal( sock.dontwait(1), true, 'sock.dontwait(1) sets: 1');
-  t.equal( sock.dontwait(), 1, 'sock.dontwait(1) gets: 1');
+  t.equal( sock.dontwait(true), true, 'sock.dontwait(true) sets: true');
+  t.equal( sock.dontwait(), true, 'sock.dontwait(1) gets: true');
 
   //get default dontwait option for pull
   var pull = nano.socket('pull');
-  t.equal( pull.dontwait(), 1, 'sock.dontwait() gets: 1');
+  t.equal( pull.dontwait(), true, 'sock.dontwait() gets: true');
   pull.close();
 
   sock.close();

--- a/test/sockoptapi.js
+++ b/test/sockoptapi.js
@@ -75,6 +75,18 @@ test('sockopt api methods', function(t){
   t.equal( sock.wsopt('binary'), true, 'sock.wsopt(binary) sets: binary');
   t.equal( sock.wsopt(), 'binary', 'sock.wsopt() gets: binary');
 
+  //get default dontwait option for push
+  t.equal( sock.dontwait(), 0, 'sock.dontwait() gets: 0');
+
+  //set dontwait option
+  t.equal( sock.dontwait(1), true, 'sock.dontwait(1) sets: 1');
+  t.equal( sock.dontwait(), 1, 'sock.dontwait(1) gets: 1');
+
+  //get default dontwait option for pull
+  var pull = nano.socket('pull');
+  t.equal( pull.dontwait(), 1, 'sock.dontwait() gets: 1');
+  pull.close();
+
   sock.close();
   t.end();
 });


### PR DESCRIPTION
fixes #173 

the NN_DONTWAIT flag is: 
* zero (for blocking) or
* one (for async I/O)

We can set the option (including override PUSH default) by doing:

```js
var push = require('nanomsg').socket('push', { dontwait: 1 } ); // async I/O

var pull = require('nanomsg').socket('pull', { dontwait: 0 } ); // socket blocks
```



@nickdesaulniers, review? ~~Should we also add a note about this in the readme?~~

