### PR TITLE
delete old/unused Socket methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ libtool
 nanocat
 .libs
 v8
+package-lock.json

--- a/lib/index.js
+++ b/lib/index.js
@@ -309,15 +309,6 @@ Socket.prototype.send = function (buf, flags) {
     return buf.length;
 };
 
-/* returns an int, a string, or throws EBADF, ENOPROTOOPT, ETERM */
-Socket.prototype.getsockopt = function (level, option) {
-    return this._protectArray(nn.Getsockopt(this.binding, level, option));
-};
-
-Socket.prototype.setsockopt = function (level, option, value) {
-    return this._protect(nn.Setsockopt(this.binding, level, option, value));
-};
-
 /**
  * Device implementation
  */


### PR DESCRIPTION
details for PR in commit with extra rambling and entertainment on what this code was

also we need to add support for TTL option:

> NN_TTL
Retrieves the maximum number of "hops" a message can go through before it is dropped. Each time the message is received (for example via the nn_device(3) function) counts as a single hop. This provides a form of protection against inadvertent loops.

http://nanomsg.org/v1.0.0/nn_getsockopt.3.html

also suspect #178 has been detained in the closed tab... 🚔 