### PR TITLE
add NN_MAXTTL option to sockopt api

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Starts a new socket. The nanomsg socket can bind or connect to multiple heteroge
 nano.socket('bus', { raw: true } );
 ```
 * `'tcpnodelay'` *(Boolean, default: `false`)*: see [`socket.tcpnodelay(boolean)`](https://github.com/nickdesaulniers/node-nanomsg#sockettcpnodelayboolean)
+* `'maxttl'` *(Number, default: `8`)*: see [`socket.maxttl(hops)`](https://github.com/nickdesaulniers/node-nanomsg#socketmaxttlhops)
 * `'linger'` *(Number, default: `1000`)*: see [`socket.linger(duration)`](https://github.com/nickdesaulniers/node-nanomsg#socketlingerduration)
 * `'sndbuf'` *(Number, size in bytes, default: `128kB`)*: see [`socket.sndbuf(size)`](https://github.com/nickdesaulniers/node-nanomsg#socketsndbufsize)
 * `'rcvbuf'` *(Number, size in bytes, default: `128kB`)*: see [`socket.rcvbuf(size)`](https://github.com/nickdesaulniers/node-nanomsg#socketrcvbufsize)
@@ -192,6 +193,20 @@ console.log(socket.tcpnodelay()); //tcp nodelay: off
 socket.tcpnodelay(true); //disabling Nagle's algorithm
 
 console.log(socket.tcpnodelay()); //tcp nodelay: on
+```
+
+### socket.maxttl(hops)
+
+*(Function, param: Number, default: `8`)*: Sets the maximum number of "hops" a
+message can go through before it is dropped. Each time the message is received
+(for example via the `nn_device(3)` function) counts as a single hop. This
+provides a form of protection against inadvertent loops.
+
+Pass no parameter for the socket's maxttl hop count.
+
+```js
+socket.maxttl(4);
+console.log(socket.maxttl()); // 4
 ```
 
 ### socket.linger(duration)

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ var sol = {
   rcvmaxsize      : nn.NN_RCVMAXSIZE,
   tcpnodelay      : nn.NN_TCP_NODELAY,
   ipv6            : nn.NN_IPV4ONLY,
+  maxttl          : nn.NN_MAXTTL,
 }
 
 /**
@@ -354,6 +355,7 @@ Socket.prototype.maxreconn  = opt('maxreconn');
 Socket.prototype.sndprio    = opt('sndprio');
 Socket.prototype.rcvprio    = opt('rcvprio');
 Socket.prototype.rcvmaxsize = opt('rcvmaxsize');
+Socket.prototype.maxttl     = opt('maxttl');
 
 /* ipv6 & tcpnodelay sockopt methods. these two opts are a little different */
 Socket.prototype.ipv6 = function (bool) {

--- a/test/sockoptapi.js
+++ b/test/sockoptapi.js
@@ -68,6 +68,11 @@ test('sockopt api methods', function(t){
   t.equal( sock.ipv6(true), true, 'sock.ipv6(true) gets: true');
   t.equal( sock.ipv6(), true, 'sock.ipv6() gets: true');
 
+  //maxttl
+  t.equal( sock.maxttl(), 8, 'sock.maxttl() gets: 8');
+  t.equal( sock.maxttl(12), true, 'sock.maxttl(12) sets: 12');
+  t.equal( sock.maxttl(), 12, 'sock.maxttl() gets: 12');
+
   //set WS socket msg type
   t.equal( sock.wsopt(), 'binary', 'sock.wsopt() gets: binary');
   t.equal( sock.wsopt('text'), true, 'sock.wsopt(text) sets: text');


### PR DESCRIPTION
fixes #180 making the option available from the sockopt api:

### socket.maxttl(hops)

*(Function, param: Number, default: `8`)*: Sets the maximum number of "hops" a message can go through before it is dropped. Each time the message is received (for example via the `nn_device(3)` function) counts as a single hop. This provides a form of protection against inadvertent loops.

Pass no parameter for the socket's maxttl hop count.

```js
socket.maxttl(4);
console.log(socket.maxttl()); // 4
```

@nickdesaulniers, review?