### PR TITLE
unix IPC fix: a new-ish define flag automatically cleans up descriptor

### DIFF
--- a/deps/linux.gypi
+++ b/deps/linux.gypi
@@ -16,6 +16,7 @@
         'NN_HAVE_GCC_ATOMIC_BUILTINS',
         'NN_HAVE_MSG_CONTROL',
         'NN_USE_EVENTFD',
+        'NN_HAVE_UNIX_SOCKETS',
     ],
     'sources':[
         'nanomsg/src/aio/poller.c',

--- a/deps/macosx.gypi
+++ b/deps/macosx.gypi
@@ -27,6 +27,7 @@
         'NN_HAVE_POLL',
         'NN_USE_KQUEUE',
         'NN_HAVE_MSG_CONTROL',
+        'NN_HAVE_UNIX_SOCKETS',
     ],
     'sources':[
         'nanomsg/src/aio/poller.c',

--- a/test/connect.js
+++ b/test/connect.js
@@ -29,7 +29,6 @@ test('map connect address eid for valid IPC address', function (t) {
   }
 
   sock.close();
-  require('fs').unlinkSync('some_address');
 });
 
 test('map connect address eid for valid TCP address', function (t) {

--- a/test/ipc.js
+++ b/test/ipc.js
@@ -5,7 +5,6 @@
 
 var nano    = require('..')
 var test    = require('tape')
-var unlink  = require('fs').unlinkSync
 
 test('ipc socket pub sub', function (t) {
     t.plan(1);
@@ -24,7 +23,6 @@ test('ipc socket pub sub', function (t) {
 
         pub.close();
         sub.close();
-        unlink('/tmp/pubsub.ipc')
     });
 
     setTimeout(function () {
@@ -49,7 +47,6 @@ test('ipc socket pairs', function (t) {
 
         s1.close();
         s2.close();
-        unlink('/tmp/pairs.ipc')
     });
 
     setTimeout(function () {
@@ -80,7 +77,6 @@ test('ipc socket req rep', function (t) {
 
         req.close();
         rep.close();
-        unlink('/tmp/reqrep.ipc')
     });
 
     setTimeout(function () {
@@ -122,7 +118,6 @@ test('ipc socket survey', function (t) {
             rep1.close();
             rep2.close();
             rep3.close();
-            unlink('/tmp/survey.ipc')
         }
     });
 
@@ -168,7 +163,6 @@ test('ipc socket bus', function (t) {
                     // close all buses.
                     Object.keys(buses).forEach(function (addr) {
                         buses[addr].close();
-                        unlink(addr.split(/:\/\//)[1])
                     });
                 }
             });
@@ -224,7 +218,6 @@ test('ipc multiple socket pub sub', function (t) {
             sub1.close();
             sub2.close();
             sub3.close();
-            unlink('/tmp/multisub.ipc')
         }
     };
 


### PR DESCRIPTION
Fixes #191 

@art32, we always cleaned up IPC sockets on unixes manually before, but we should have been using this feature since beta-9


An honorable mention/ref for @Snaipe and @gdamore for adding this handy way to clean up IPC sockets from the `NN_HAVE_UNIX_SOCKETS ` define.  cheers! thanks guys! 🍻  

*Note: for a Node.JS binding we specify library defines auto-populated during OS detection step of a regular build/compile... those need to be manually spelled out in `.gyp` `defines` array*



refs:
  • https://github.com/nanomsg/nanomsg/commit/c08f6f98dc72b89dd53989f97f01943f63d1a936#diff-b0d243dce80d72524ecf035d9c987bbc

  • https://github.com/nanomsg/nanomsg/issues/666


@nickdesaulniers, review?