### PR TITLE
update nan@2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "bindings": "1.2.1",
-    "nan": "2.4"
+    "nan": "2.8"
   },
   "devDependencies": {
     "buffer-equals-polyfill": "1.0.0",


### PR DESCRIPTION
this PR updates NAN and gets rid of this deprecation message on install:

```bash
../node_modules/nan/nan_maybe_43_inl.h:112:15: warning: 'ForceSet' is deprecated [-Wdeprecated-declarations]
  return obj->ForceSet(isolate->GetCurrentContext(), key, value, attribs);
              ^
/Users/bent/.node-gyp/9.4.0/include/node/v8.h:3114:3: note: 'ForceSet' has been explicitly marked deprecated here
  V8_DEPRECATED("Use CreateDataProperty / DefineOwnProperty",
  ^
/Users/bent/.node-gyp/9.4.0/include/node/v8config.h:321:29: note: expanded from macro 'V8_DEPRECATED'
  declarator __attribute__((deprecated))
                            ^
1 warning generated.
  CXX(target) Release/obj.target/node_nanomsg/src/poll_ctx.o
In file included from ../src/poll_ctx.cc:2:
In file included from ../src/poll_ctx.h:3:
In file included from ../node_modules/nan/nan.h:192:
../node_modules/nan/nan_maybe_43_inl.h:112:15: warning: 'ForceSet' is deprecated [-Wdeprecated-declarations]
  return obj->ForceSet(isolate->GetCurrentContext(), key, value, attribs);
              ^
/Users/bent/.node-gyp/9.4.0/include/node/v8.h:3114:3: note: 'ForceSet' has been explicitly marked deprecated here
  V8_DEPRECATED("Use CreateDataProperty / DefineOwnProperty",
  ^
/Users/bent/.node-gyp/9.4.0/include/node/v8config.h:321:29: note: expanded from macro 'V8_DEPRECATED'
  declarator __attribute__((deprecated))
                            ^
1 warning generated.
  SOLINK_MODULE(target) Release/node_nanomsg.node
```

Also i think we might have to drop node `v0.12` and `v0.10` for this

@nickdesaulniers, 

review?