### PR TITLE
package.json: fix vulnerable devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "esformatter": "0.0.16",
     "tap-difflet": "0.3.0",
     "tap-nyan": "0.0.2",
-    "tape": "~2.12.0"
+    "tape": "4.11.0"
   },
   "scripts": {
     "test": "find test/*.js test/standalone/*.js | xargs -n 1 node | node_modules/tap-nyan/bin/cmd.js",


### PR DESCRIPTION
Looks like 2 packages we used in our test harness (tap-difflet, tape)
had vulnerability reports.

Fixes #208