### PR TITLE
Fix new Buffer() deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "nan": "2.8"
   },
   "devDependencies": {
+    "buffer-alloc": "1.2.0",
     "buffer-equals-polyfill": "1.0.0",
+    "buffer-from": "1.1.1",
     "esformatter": "0.0.16",
     "tap-difflet": "0.3.0",
     "tap-nyan": "0.0.2",

--- a/perf/common.js
+++ b/perf/common.js
@@ -1,11 +1,12 @@
 'use strict';
 
+var buffer_alloc = require('buffer-alloc')
+
 exports.createMsg = function(msgType, sz) {
   var buf;
   switch (msgType) {
     case '--buffer':
-      buf = new Buffer(sz);
-      buf.fill('o');
+      buf = Buffer_alloc(sz, 'o');
       break;
     case '--string':
       buf = new Array(sz + 1).join('o');

--- a/test/send.js
+++ b/test/send.js
@@ -2,6 +2,7 @@
 
 var nano = require('..');
 var test = require('tape');
+var buffer_from = require('buffer-from');
 
 // Polyfills Buffer.prototype.equals for Node.js 0.10
 // See: https://github.com/nickdesaulniers/node-nanomsg/issues/82
@@ -54,7 +55,7 @@ test('send can take a buffer', function (t) {
   var pub = nano.socket('pub');
   var sub = nano.socket('sub');
   var addr = 'inproc://some_address';
-  var msg = new Buffer('hello');
+  var msg = buffer_from('hello');
 
   pub.bind(addr);
   sub.connect(addr);
@@ -85,7 +86,7 @@ test('should not null terminate when sending strings', function (t) {
     if (buf[buf.length - 1] === 0) {
       t.fail();
     }
-    t.equal(buf.equals(new Buffer(msg)), true);
+    t.equal(buf.equals(buffer_from(msg)), true);
     t.equal(buf.length, msg.length);
     pub.close();
     sub.close();

--- a/test/transform.js
+++ b/test/transform.js
@@ -3,14 +3,15 @@
 
 var nano = require('../');
 var test = require('tape');
+var buffer_from = require('buffer-from');
 
 nano.Socket.prototype.transform = function (buf) {
-    if (!Buffer.isBuffer(buf)) buf = new Buffer(buf);
-    return Buffer.concat([new Buffer([0x00]), buf]);
+    if (!Buffer.isBuffer(buf)) buf = buffer_from(buf);
+    return Buffer.concat([buffer_from([0x00]), buf]);
 }
 
 nano.Socket.prototype.restore = function (buf) {
-    return Buffer.concat([new Buffer([0xFF]), buf]);
+    return Buffer.concat([buffer_from([0xFF]), buf]);
 }
 
 test('inproc socket pub sub', function (t) {


### PR DESCRIPTION
When running npm test, I was observing warnings from calling new
Buffer().  Looks like newer versions of node provide and prefer the use
of Buffer.alloc() and Buffer.from().  Unfortunately, these can't be used
as-is by packages such as node-nanomsg because they aren't available in
old versions of Node.js that we support.

Add pollyfill dependencies from Buffer.alloc() and Buffer.from() and use
those in our tests.

Fixes #210