### PR TITLE
linux.gypi: audit cflags passed to nanomsg

### DIFF
--- a/deps/linux.gypi
+++ b/deps/linux.gypi
@@ -22,8 +22,8 @@
         'nanomsg/src/aio/poller.c',
     ],
     'cflags': [
-        '-O3', '-Wall', '-Wextra', '-Wno-sign-compare', '-Wno-strict-aliasing',
-        '-Wno-unused', '-Wno-char-subscripts', '-Wno-maybe-uninitialized',
-        '-Wno-implicit-function-declaration', '-lpthread',
+        '-O3', '-Wall', '-Wextra',
+        '-Wno-implicit-fallthrough',
+        '-Wno-unused-variable',
     ],
 }


### PR DESCRIPTION
I suspect these were copied from w/e Makefile upstream nanomsg used at
the time.  Looks like they've since moved to CMake and now just set
-Wall -Wextra.

Remove old flags we don't need anymore, and add new ones to silence the
warnings in our current snapshot of nanomsg.

These flags should be audited and potentially removed (or added) next
time we uprev our snapshot of nanomsg.

Fixes #215