### PR TITLE
fix for node.js versions > 13

### DIFF
--- a/src/poll_ctx.cc
+++ b/src/poll_ctx.cc
@@ -40,5 +40,5 @@ PollCtx* PollCtx::UnwrapPointer (v8::Local<v8::Value> buffer) {
    std::shared_ptr<v8::BackingStore> ab_c = abuf->GetBackingStore();
    abuf->Detach();
    return reinterpret_cast<PollCtx*>(node::Buffer::HasInstance(buffer) ?
-      static_cast<char*>(ab_c->Data()) : NULL  );
+      static_cast<char*>(ab_c->Data()) : NULL );
 }

--- a/src/poll_ctx.cc
+++ b/src/poll_ctx.cc
@@ -35,6 +35,10 @@ v8::Local<v8::Value> PollCtx::WrapPointer (void* ptr, size_t length) {
 }
 
 PollCtx* PollCtx::UnwrapPointer (v8::Local<v8::Value> buffer) {
-  return reinterpret_cast<PollCtx*>(node::Buffer::HasInstance(buffer) ?
-    node::Buffer::Data(buffer.As<v8::Object>()) : NULL);
+   v8::Local<v8::ArrayBufferView> ui = buffer.As<v8::ArrayBufferView>();
+   v8::Local<v8::ArrayBuffer> abuf = ui->Buffer();
+   std::shared_ptr<v8::BackingStore> ab_c = abuf->GetBackingStore();
+   abuf->Detach();
+   return reinterpret_cast<PollCtx*>(node::Buffer::HasInstance(buffer) ?
+      static_cast<char*>(ab_c->Data()) : NULL  );
 }


### PR DESCRIPTION
PollCtx::UnwrapPointer was causing crashes in Node.js versions greater than 13.x.