### PR TITLE
Support Electron > 14

### DIFF
--- a/src/node_nanomsg.cc
+++ b/src/node_nanomsg.cc
@@ -283,4 +283,4 @@ NAN_MODULE_INIT(InitAll) {
   }
 }
 
-NODE_MODULE(node_nanomsg, InitAll)
+NAN_MODULE_WORKER_ENABLED(node_nanomsg, InitAll)


### PR DESCRIPTION
Use updated NAN_MODULE_WORKER_ENABLED macro from nan (which takes care of nodejs versioning)
https://github.com/nodejs/nan/commit/b058fb047d18a58250e66ae831444441c1f2ac7a

See electron deprecation issue:
https://github.com/electron/electron/issues/18397

Solves https://github.com/nickdesaulniers/node-nanomsg/issues/224